### PR TITLE
Update .gitmodules with absolute URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,27 +1,27 @@
 [submodule "Resources/Binary"]
 	path = Resources/Binary
-	url = ../oolite-binary-resources.git
+	url = https://OoliteProject/oolite-binary-resources.git
 [submodule "Mac-specific"]
 	path = Mac-specific
-	url = ../oolite-mac-components
+	url = https://OoliteProject/oolite-mac-components
 [submodule "deps/Linux-deps"]
 	path = deps/Linux-deps
-	url = ../oolite-linux-dependencies.git
+	url = https://OoliteProject/oolite-linux-dependencies.git
 [submodule "tests"]
 	path = tests
-	url = ../oolite-tests.git
+	url = https://OoliteProject/oolite-tests.git
 [submodule "deps/Cross-platform-deps"]
 	path = deps/Cross-platform-deps
-	url = ../oolite-sdl-dependencies.git
+	url = https://OoliteProject/oolite-sdl-dependencies.git
 [submodule "deps/mozilla"]
 	path = deps/mozilla
-	url = ../spidermonkey-ff4.git
+	url = https://OoliteProject/spidermonkey-ff4.git
 [submodule "deps/libogg"]
 	path = deps/libogg
-	url = ../libogg-1.3.0.git
+	url = https://OoliteProject/libogg-1.3.0.git
 [submodule "deps/libvorbis"]
 	path = deps/libvorbis
-	url = ../libvorbis-1.3.3.git
+	url = https://OoliteProject/libvorbis-1.3.3.git
 [submodule "deps/Windows-deps"]
 	path = deps/Windows-deps
-	url = ../oolite-windows-dependencies.git
+	url = https://OoliteProject/oolite-windows-dependencies.git


### PR DESCRIPTION
I'm having a problem with forking the oolite repository, which might be down to my inexperience with git, or might be due to the problem outlined below.

The problem seems to be due to the relative URL's in .gitmodules.  When I clone my fork and do a git submodule update --init, because the URL's are relative it tries to get the submodules from my fork, which don't exist.  I can fix the immediate problem by editing .git/config and changing the URL's to absolute.  However, if I edit .gitmodules to do the same than the changes appear in every pull request, which would be annoying for you guys.  If I don't edit .gitmodules then I've got to manually fix the .git/config if I clone again.  Worse still, anybody who clones/forks my repo has to do the same.

So I think the URL's in .gitmodules need to be absolute, as in the patch below.  If I'm not understanding something, please let me know!
