### PR TITLE
Gui planets

### DIFF
--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -3645,17 +3645,6 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 	if (shipData == nil)  shipData = [[OOShipRegistry sharedRegistry] shipInfoForKey:shipKey];
 	if (shipData == nil)  return;
 	
-	// Correct the position of the displayed model in the status screen when viewed in non-4/3 resolutions. Other screens displaying
-	// demoship models remain unaltered - Nikos 20140129
-	NSSize screenSize = [[UNIVERSE gameView] viewSize];
-	GLfloat screenSizeCorrectionFactor = 1.0f;
-	if ([context isEqualToString:@"GUI_SCREEN_STATUS"])
-	{
-		screenSizeCorrectionFactor = screenSize.height <= screenSize.width ?
-										screenSize.height / screenSize.width * (4.0f/3.0f) :
-										screenSize.height / screenSize.width * (3.0f/4.0f);
-	}
-	
 	Quaternion		q2 = { (GLfloat)M_SQRT1_2, (GLfloat)M_SQRT1_2, (GLfloat)0.0f, (GLfloat)0.0f };
 	// MKW - retrieve last demo ships' orientation and release it
 	if( demoShip != nil )
@@ -3673,7 +3662,7 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 	
 	GLfloat cr = [ship collisionRadius];
 	[ship setOrientation: q2];
-	[ship setPositionX:factorX * cr * screenSizeCorrectionFactor y:factorY * cr * screenSizeCorrectionFactor z:factorZ * cr];
+	[ship setPositionX:factorX * cr y:factorY * cr z:factorZ * cr];
 	[ship setScanClass: CLASS_NO_DRAW];
 	[ship setRoll: M_PI/10.0];
 	[ship setPitch: M_PI/25.0];

--- a/src/Core/Universe.m
+++ b/src/Core/Universe.m
@@ -4414,7 +4414,7 @@ static const OOMatrix	starboard_matrix =
 				}
 				else
 				{
-					OOGLFrustum(-ratio/aspect, ratio/aspect, -ratio, ratio, nearPlane, farPlane);
+					OOGLFrustum(-3*ratio/aspect/4, 3*ratio/aspect/4, -3*ratio/4, 3*ratio/4, nearPlane, farPlane);
 				}
 
 				[self getActiveViewMatrix:&view_matrix forwardVector:&view_dir upVector:&view_up];

--- a/src/Core/Universe.m
+++ b/src/Core/Universe.m
@@ -4388,6 +4388,8 @@ static const OOMatrix	starboard_matrix =
 			
 			OOSetOpenGLState(OPENGL_STATE_OPAQUE);  // FIXME: should be redundant.
 			
+			OOGL(glClear(GL_COLOR_BUFFER_BIT));
+
 			if (!displayGUI)
 			{
 				OOGL(glClearColor(skyClearColor[0], skyClearColor[1], skyClearColor[2], skyClearColor[3]));
@@ -4395,12 +4397,15 @@ static const OOMatrix	starboard_matrix =
 			else
 			{
 				OOGL(glClearColor(0.0, 0.0, 0.0, 0.0));
+				// If set, display background GUI image. Must be done before enabling lights to avoid dim backgrounds
+				OOGLResetProjection();
+				OOGLFrustum(-0.5, 0.5, -aspect*0.5, aspect*0.5, 1.0, MAX_CLEAR_DEPTH);
+				[gui drawGUIBackground];
+			
 			}
 
 			BOOL		fogging, bpHide = [self breakPatternHide];
 			
-			OOGL(glClear(GL_COLOR_BUFFER_BIT));
-
 			for (vdist=0;vdist<=1;vdist++)
 			{
 				float   nearPlane = vdist ? 1.0 : INTERMEDIATE_CLEAR_DEPTH;
@@ -4445,9 +4450,6 @@ static const OOMatrix	starboard_matrix =
 				 * handled a little more carefully than before.
 				 */
 
-				// If set, display background GUI image. Must be done before enabling lights to avoid dim backgrounds
-				if (displayGUI)  [gui drawGUIBackground];
-			
 				OOSetOpenGLState(OPENGL_STATE_OPAQUE); 
 				// clearing the depth buffer waits until we've set
 				// STATE_OPAQUE so that depth writes are definitely

--- a/src/Core/Universe.m
+++ b/src/Core/Universe.m
@@ -4408,7 +4408,14 @@ static const OOMatrix	starboard_matrix =
 				float   ratio = (displayGUI ? 0.5 : [gameView fov:YES]) * nearPlane; // 0.5 is field of view ratio for GUIs
 				
 				OOGLResetProjection();
-				OOGLFrustum(-ratio, ratio, -aspect*ratio, aspect*ratio, nearPlane, farPlane);
+				if (!displayGUI || 3*aspect >= 4 )
+				{
+					OOGLFrustum(-ratio, ratio, -aspect*ratio, aspect*ratio, nearPlane, farPlane);
+				}
+				else
+				{
+					OOGLFrustum(-ratio/aspect, ratio/aspect, -ratio, ratio, nearPlane, farPlane);
+				}
 
 				[self getActiveViewMatrix:&view_matrix forwardVector:&view_dir upVector:&view_up];
 

--- a/src/Core/Universe.m
+++ b/src/Core/Universe.m
@@ -4408,7 +4408,7 @@ static const OOMatrix	starboard_matrix =
 				float   ratio = (displayGUI ? 0.5 : [gameView fov:YES]) * nearPlane; // 0.5 is field of view ratio for GUIs
 				
 				OOGLResetProjection();
-				if (!displayGUI || 3*aspect >= 4 )
+				if (!displayGUI || 4*aspect >= 3 )
 				{
 					OOGLFrustum(-ratio, ratio, -aspect*ratio, aspect*ratio, nearPlane, farPlane);
 				}

--- a/src/Core/Universe.m
+++ b/src/Core/Universe.m
@@ -4413,7 +4413,7 @@ static const OOMatrix	starboard_matrix =
 				float   ratio = (displayGUI ? 0.5 : [gameView fov:YES]) * nearPlane; // 0.5 is field of view ratio for GUIs
 				
 				OOGLResetProjection();
-				if (!displayGUI || 4*aspect >= 3 )
+				if ((displayGUI && 4*aspect >= 3) || (!displayGUI && 4*aspect <= 3))
 				{
 					OOGLFrustum(-ratio, ratio, -aspect*ratio, aspect*ratio, nearPlane, farPlane);
 				}


### PR DESCRIPTION
Fix for issue mentioned on the mailing list where the planet in the system info screen was being rendered at unusual sizes when the window has odd aspect ratios.  Obviously, this can be delayed until after 1.82 release.