### PR TITLE
Multiple laser mounts

### DIFF
--- a/src/Core/Entities/PlayerEntity.h
+++ b/src/Core/Entities/PlayerEntity.h
@@ -941,7 +941,7 @@ typedef enum
 
 - (OOWeaponType) weaponForFacing:(OOWeaponFacing)facing;
 - (OOWeaponType) currentWeapon;
-- (Vector) currentLaserOffset;
+- (NSArray *) currentLaserOffset;
 
 - (void) rotateCargo;
 

--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -5668,7 +5668,14 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 
 	[self currentWeaponStats];
 
-	if (energy <= weapon_energy_use)
+	NSUInteger multiplier = 1;
+	if (_multiplyWeapons)
+	{
+		// multiple fitted
+		multiplier = [[self laserPortOffset:currentWeaponFacing] count];
+	}
+	
+	if (energy <= weapon_energy_use * multiplier)
 	{
 		[UNIVERSE addMessage:DESC(@"weapon-out-of-juice") forCount:3.0];
 		return NO;
@@ -5676,27 +5683,27 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 
 	using_mining_laser = [weapon_to_be_fired isMiningLaser];
 
-	energy -= weapon_energy_use;
+	energy -= weapon_energy_use * multiplier;
 
 	switch (currentWeaponFacing)
 	{
 		case WEAPON_FACING_FORWARD:
-			forward_weapon_temp += weapon_shot_temperature;
+			forward_weapon_temp += weapon_shot_temperature * multiplier;
 			forward_shot_time = 0.0;
 			break;
 			
 		case WEAPON_FACING_AFT:
-			aft_weapon_temp += weapon_shot_temperature;
+			aft_weapon_temp += weapon_shot_temperature * multiplier;
 			aft_shot_time = 0.0;
 			break;
 			
 		case WEAPON_FACING_PORT:
-			port_weapon_temp += weapon_shot_temperature;
+			port_weapon_temp += weapon_shot_temperature * multiplier;
 			port_shot_time = 0.0;
 			break;
 			
 		case WEAPON_FACING_STARBOARD:
-			starboard_weapon_temp += weapon_shot_temperature;
+			starboard_weapon_temp += weapon_shot_temperature * multiplier;
 			starboard_shot_time = 0.0;
 			break;
 			

--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -5639,7 +5639,7 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 }
 
 
-- (Vector) currentLaserOffset
+- (NSArray *) currentLaserOffset
 {
 	return [self laserPortOffset:currentWeaponFacing];
 }
@@ -5656,7 +5656,7 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 	
 	if (weapon_temp / PLAYER_MAX_WEAPON_TEMP >= WEAPON_COOLING_CUTOUT)
 	{
-		[self playWeaponOverheated:[self currentLaserOffset]];
+		[self playWeaponOverheated:[[self currentLaserOffset] oo_vectorAtIndex:0]];
 		[UNIVERSE addMessage:DESC(@"weapon-overheat") forCount:3.0];
 		return NO;
 	}

--- a/src/Core/Entities/PlayerEntityControls.m
+++ b/src/Core/Entities/PlayerEntityControls.m
@@ -978,7 +978,7 @@ static NSTimeInterval	time_last_frame;
 				{
 					if ([self fireMainWeapon])
 					{
-						[self playLaserHit:([self shipHitByLaser] != nil) offset:[self currentLaserOffset]];
+						[self playLaserHit:([self shipHitByLaser] != nil) offset:[[self currentLaserOffset] oo_vectorAtIndex:0]];
 					}
 				}
 				

--- a/src/Core/Entities/ShipEntity.h
+++ b/src/Core/Entities/ShipEntity.h
@@ -386,11 +386,13 @@ typedef enum
 	
 	GLfloat					_scaleFactor;  // scale factor for size variation
 
+
+	BOOL					_multiplyWeapons; // multiply instead of splitting weapons
 	//position of gun ports
-	Vector					forwardWeaponOffset,
-							aftWeaponOffset,
-							portWeaponOffset,
-							starboardWeaponOffset;
+	NSArray					*forwardWeaponOffset,
+							*aftWeaponOffset,
+							*portWeaponOffset,
+							*starboardWeaponOffset;
 	
 	// crew (typically one OOCharacter - the pilot)
 	NSArray					*crew;
@@ -582,11 +584,11 @@ typedef enum
 
 - (NSDictionary *)shipInfoDictionary;
 
-- (void) setDefaultWeaponOffsets;
-- (Vector) aftWeaponOffset;
-- (Vector) forwardWeaponOffset;
-- (Vector) portWeaponOffset;
-- (Vector) starboardWeaponOffset;
+- (NSArray *) getWeaponOffsetFrom:(NSDictionary *)dict withKey:(NSString *)key inMode:(NSString *)mode;
+- (NSArray *) aftWeaponOffset;
+- (NSArray *) forwardWeaponOffset;
+- (NSArray *) portWeaponOffset;
+- (NSArray *) starboardWeaponOffset;
 - (BOOL) hasAutoWeapons;
 
 - (BOOL) isFrangible;
@@ -1110,11 +1112,10 @@ Vector positionOffsetForShipInRotationToAlignment(ShipEntity* ship, Quaternion q
 - (BOOL) fireDirectLaserShot:(double)range;
 - (BOOL) fireDirectLaserDefensiveShot;
 - (BOOL) fireDirectLaserShotAt:(Entity *)my_target;
-- (Vector) laserPortOffset:(OOWeaponFacing)direction;
+- (NSArray *) laserPortOffset:(OOWeaponFacing)direction;
 - (BOOL) fireLaserShotInDirection:(OOWeaponFacing)direction;
 - (void) adjustMissedShots:(int)delta;
 - (int) missedShots;
-- (BOOL) firePlasmaShotAtOffset:(double)offset speed:(double)speed color:(OOColor *)color;
 - (void) considerFiringMissile:(double)delta_t;
 - (Vector) missileLaunchPosition;
 - (ShipEntity *) fireMissile;

--- a/src/Core/Entities/ShipEntity.m
+++ b/src/Core/Entities/ShipEntity.m
@@ -1971,7 +1971,7 @@ static ShipEntity *doOctreesCollide(ShipEntity *prime, ShipEntity *other);
 }
 
 
-#define MAKE_VECTOR_ARRAY(v) [NSArray arrayWithObjects:[NSNumber numberWithFloat:v.x], [NSNumber numberWithFloat:v.y], [NSNumber numberWithFloat:v.z], nil]
+#define MAKE_VECTOR_ARRAY(v) [[[OONativeVector alloc] initWithVector:v] autorelease]
 
 - (NSArray *) getWeaponOffsetFrom:(NSDictionary *)dict withKey:(NSString *)key inMode:(NSString *)mode
 {
@@ -11467,7 +11467,10 @@ Vector positionOffsetForShipInRotationToAlignment(ShipEntity* ship, Quaternion q
 		ShipEntity		*se = nil;
 		for (subEnum = [self shipSubEntityEnumerator]; (se = [subEnum nextObject]); )
 		{
-			if ([se fireSubentityLaserShot:range])  fired = YES;
+			if ([se fireSubentityLaserShot:range])
+			{
+				fired = YES;
+			}
 		}
 	}
 	

--- a/src/Core/OOCollectionExtractors.m
+++ b/src/Core/OOCollectionExtractors.m
@@ -1409,7 +1409,11 @@ Vector OOVectorFromObject(id object, Vector defaultValue)
 	Vector				result = defaultValue;
 	NSDictionary		*dict = nil;
 	
-	if ([object isKindOfClass:[NSString class]])
+	if ([object isKindOfClass:[OONativeVector class]])
+	{
+		result = [object getVector];
+	}
+	else if ([object isKindOfClass:[NSString class]])
 	{
 		// This will only write result if a valid vector is found, and will write an error message otherwise.
 		ScanVectorFromString(object, &result);

--- a/src/Core/OOVector.h
+++ b/src/Core/OOVector.h
@@ -131,6 +131,18 @@ OOINLINE Vector normal_to_surface(Vector v1, Vector v2, Vector v3) CONST_FUNC;
 
 #if __OBJC__
 NSString *VectorDescription(Vector vector);	// @"(x, y, z)"
+
+/* For storing vectors in NSArrays */
+@interface OONativeVector: NSObject
+{
+@private
+	Vector v;
+}
+- (id) initWithVector:(Vector)vect;
+- (Vector) getVector;
+
+@end
+
 #endif
 
 #if OOMATHS_OPENGL_INTEGRATION

--- a/src/Core/OOVector.m
+++ b/src/Core/OOVector.m
@@ -44,7 +44,29 @@ NSString *VectorDescription(Vector vector)
 {
 	return [NSString stringWithFormat:@"(%g, %g, %g)", vector.x, vector.y, vector.z];
 }
+
+@implementation OONativeVector
+
+- (id) initWithVector:(Vector)vect
+{
+	self = [super init];
+	if (EXPECT_NOT(self == nil))  return nil;
+
+	v = vect;
+
+	return self;
+}
+
+- (Vector) getVector
+{
+	return v;
+}
+
+
+@end
+
 #endif
+
 
 
 #if !OOMATHS_STANDALONE

--- a/src/Core/Scripting/OOJSShip.m
+++ b/src/Core/Scripting/OOJSShip.m
@@ -4122,6 +4122,9 @@ static JSBool ShipThreatAssessment(JSContext *context, uintN argc, jsval *vp)
 
 		// check lasers
 		OOWeaponType wt = [thisEnt weaponTypeIDForFacing:WEAPON_FACING_FORWARD strict:NO];
+		/* Not affected by multiple mounts here: they're either just a
+		 * split of the power, or only more dangerous until they
+		 * overheat */
 		assessment += ShipThreatAssessmentWeapon(wt);
 		if (isWeaponNone(wt))
 		{

--- a/src/Core/Scripting/OOJSShip.m
+++ b/src/Core/Scripting/OOJSShip.m
@@ -813,16 +813,21 @@ static JSBool ShipGetProperty(JSContext *context, JSObject *this, jsid propID, j
 			return JS_NewNumberValue(context, [entity weaponFacings], value);
 		
 		case kShip_weaponPositionAft:
-			return VectorToJSValue(context, [entity aftWeaponOffset], value);
+			result = [entity aftWeaponOffset];
+			break;
 		
 		case kShip_weaponPositionForward:
-			return VectorToJSValue(context, [entity forwardWeaponOffset], value);
+			result = [entity forwardWeaponOffset];
+			break;
+//			return VectorToJSValue(context, [entity forwardWeaponOffset], value);
 		
 		case kShip_weaponPositionPort:
-			return VectorToJSValue(context, [entity portWeaponOffset], value);
+			result = [entity portWeaponOffset];
+			break;
 		
 		case kShip_weaponPositionStarboard:
-			return VectorToJSValue(context, [entity starboardWeaponOffset], value);
+			result = [entity starboardWeaponOffset];
+			break;
 		
 		case kShip_scannerRange:
 			return JS_NewNumberValue(context, [entity scannerRange], value);

--- a/src/Core/Scripting/OOJSVector.h
+++ b/src/Core/Scripting/OOJSVector.h
@@ -73,3 +73,6 @@ BOOL VectorFromArgumentList(JSContext *context, NSString *scriptClass, NSString 
 	Like VectorFromArgumentList(), but does not report an error on failure.
 */
 BOOL VectorFromArgumentListNoError(JSContext *context, uintN argc, jsval *argv, HPVector *outVector, uintN *outConsumed)  GCC_ATTR((nonnull (1, 3, 4)));
+
+
+

--- a/src/Core/Scripting/OOJSVector.m
+++ b/src/Core/Scripting/OOJSVector.m
@@ -1136,3 +1136,5 @@ static JSBool VectorStaticRandomDirectionAndLength(JSContext *context, uintN arg
 	
 	OOJS_PROFILE_EXIT
 }
+
+

--- a/src/Core/Scripting/OOJavaScriptEngine.m
+++ b/src/Core/Scripting/OOJavaScriptEngine.m
@@ -1904,6 +1904,17 @@ NSString *OOJSDescribeValue(JSContext *context, jsval value, BOOL abbreviateObje
 
 @end
 
+@implementation OONativeVector (OOJavaScriptConversion)
+
+- (jsval)oo_jsValueInContext:(JSContext *)context
+{
+	jsval value = JSVAL_VOID;
+	VectorToJSValue(context, v, &value);
+	return value;
+}
+
+@end
+
 
 @implementation NSDictionary (OOJavaScriptConversion)
 

--- a/src/Core/Universe.m
+++ b/src/Core/Universe.m
@@ -5745,28 +5745,28 @@ static BOOL MaintainLinkedLists(Universe *uni)
 	{
 		case VIEW_FORWARD:
 			targetFacing = WEAPON_FACING_FORWARD;
-			laserPortOffset = [player forwardWeaponOffset];
+			laserPortOffset = [[player forwardWeaponOffset] oo_vectorAtIndex:0];
 			break;
 			
 		case VIEW_AFT:
 			targetFacing = WEAPON_FACING_AFT;
-			laserPortOffset = [player aftWeaponOffset];
+			laserPortOffset = [[player aftWeaponOffset] oo_vectorAtIndex:0];
 			break;
 			
 		case VIEW_PORT:
 			targetFacing = WEAPON_FACING_PORT;
-			laserPortOffset = [player portWeaponOffset];
+			laserPortOffset = [[player portWeaponOffset] oo_vectorAtIndex:0];
 			break;
 			
 		case VIEW_STARBOARD:
 			targetFacing = WEAPON_FACING_STARBOARD;
-			laserPortOffset = [player starboardWeaponOffset];
+			laserPortOffset = [[player starboardWeaponOffset] oo_vectorAtIndex:0];
 			break;
 			
 		default:
 			// Match behaviour of -firstEntityTargetedByPlayer.
 			targetFacing = WEAPON_FACING_FORWARD;
-			laserPortOffset = [player forwardWeaponOffset];
+			laserPortOffset = [[player forwardWeaponOffset] oo_vectorAtIndex:0];
 	}
 	
 	return [self firstShipHitByLaserFromShip:PLAYER inDirection:targetFacing offset:laserPortOffset gettingRangeFound:NULL];


### PR DESCRIPTION
This is a rewrite of the laser mount code to allow multiple mount points to be fitted on a single direction in a nicer way than the "subentity" pattern, including fitting multiple lasers on aft or side mounts, and including player ships.

`weapon_mount_mode` is a new shipdata property which can be "single", "split" or "multiply". "single"is the default value and duplicates 1.82 behaviour for backward compatibility. The other two change the expected value of `weapon_position_forward` (and the other three) from a vector expression to an array of vector expressions. "split" then splits the damage from the weapon across those positions - it's cosmetic only, so long as you hit with all of them; "multiply" is (mostly) equivalent to doing it with subentities in that each beam is a full power shot (though unlike the subentity solution, this has the heat and energy costs of that many full shots). You can't split some directions and multiply others, but I think that would be overcomplicating things - you can always make some custom lasers to get the same effect if you really want to do that.

Here's an experiment with a Krait
![oolite-617](https://cloud.githubusercontent.com/assets/4066616/9424497/781aa87c-48e6-11e5-9ee9-e40328fe6cd2.png)
```
weapon_mount_mode = "split";
weapon_position_aft = ("0.0 0.0 -34.6");
weapon_position_forward = (
	"45 -1.5 7",
	"-45 -1.5 7"
);
weapon_position_port = ("-45.0 0.0 -13.5");
weapon_position_starboard = ("45.0 0.0 -13.5");
```

There is a minor incompatibility for OXPs - `ship.weaponPositionForward` is now an array of vectors rather than a vector - but that was only added in 1.77 and I don't think that much makes use of it.

(Something which still probably needs doing: if the player ship has "multiply" weapons, the price of lasers should be multiplied by the number of mounts)