### PR TITLE
Adding a sell feature for equipment.

### DIFF
--- a/Resources/Config/descriptions.plist
+++ b/Resources/Config/descriptions.plist
@@ -1656,9 +1656,12 @@
 	"equip-cash-value"				= "Cash: [credits|dcr].";
 	"equip-no-equipment-available-for-purchase" = "No equipment available for purchase.";
 	"equip-repair-@"				= " Repair:%@";
+	"equip-sell-@"					= " Sell:%@";
+	"upgradeinfo-@-price-is-for-refunding" = "%@ (Price will be refunded for the existing system).";
 	"upgradeinfo-@-price-is-for-repairing" = "%@ (Price is for repairing the existing system).";
 	"@-will-replace-other-energy"	="%@ (The installed energy recharge unit will be removed and sold for scrap).";
 	"upgradeinfo-@-weight-d-of-equipment" = "%@\nTakes up %dt of cargo space.";
+	"upgradeinfo-@-frees-weight-d-of-equipment" = "%@\nFrees up %dt of cargo space.";
 	"forward-facing-string"			= " Forward ";
 	"aft-facing-string"				= " Aft ";
 	"port-facing-string"			= " Port ";

--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -8814,10 +8814,7 @@ static NSString *last_outfitting_key=nil;
 						installTime = 600 + price;
 					}
 					[gui setColor:[gui colorFromSetting:kGuiEquipmentSellColor defaultValue:[OOColor orangeColor]] forRow:row];
-					//[gui setColor:[gui colorFromSetting:kGuiEquipmentRepairColor defaultValue:[OOColor orangeColor]] forRow:row];
-
 				}
-				
 				
 				NSString *timeString = [UNIVERSE shortTimeDescription:installTime];
 				NSString *priceString = [NSString stringWithFormat:@" %@ ", OOCredits(price)];
@@ -9809,7 +9806,7 @@ static NSString *last_outfitting_key=nil;
 		{
 			return NO;
 		}
-				
+
 		// Refund current_weapon
 		if (current_weapon != nil)
 		{
@@ -10894,18 +10891,13 @@ static NSString *last_outfitting_key=nil;
 - (BOOL) canAddEquipment:(NSString *)equipmentKey inContext:(NSString *)context
 {
 	if ([equipmentKey isEqualToString:@"EQ_RENOVATION"] && !(ship_trade_in_factor < 85 || [[[self shipSubEntityEnumerator] allObjects] count] < [self maxShipSubEntities]))  return NO;
-	if (![super canAddEquipment:equipmentKey inContext:context] /*&& ![super canAddEquipmentForSale:equipmentKey inContext:context]*/)  return NO;
+	if (![super canAddEquipment:equipmentKey inContext:context])  return NO;
 	
 	NSArray *conditions = [[OOEquipmentType equipmentTypeWithIdentifier:equipmentKey] conditions];
 	if (conditions != nil && ![self scriptTestConditions:conditions])  return NO;
 	
 	return YES;
 }
-
-/*- (BOOL) canAddEquipmentForSale:(NSString *)equipmentKey inContext:(NSString *)context
-{
-	return [super canAddEquipmentForSale:equipmentKey inContext:context];
-}*/
 
 
 - (BOOL) addEquipmentItem:(NSString *)equipmentKey inContext:(NSString *)context

--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -9804,6 +9804,7 @@ static NSString *last_outfitting_key=nil;
 
 		price *= multiplier;
 		
+		credits -= price;
 		if (price > credits)
 		{
 			return NO;

--- a/src/Core/Entities/ShipEntity.h
+++ b/src/Core/Entities/ShipEntity.h
@@ -607,6 +607,7 @@ typedef enum
 - (BOOL) hasAllEquipment:(id)equipmentKeys;				// Short for hasAllEquipment:foo includeWeapons:NO
 - (BOOL) setWeaponMount:(OOWeaponFacing)facing toWeapon:(NSString *)eqKey;
 - (BOOL) canAddEquipment:(NSString *)equipmentKey inContext:(NSString *)context;		// Test ability to add equipment, taking equipment-specific constriants into account. 
+- (BOOL) canAddEquipmentForSale:(NSString *)equipmentKey /*inContext:(NSString *)context*/;		// Test ability to add equipment, taking equipment-specific constriants into account and if there is sellable. 
 - (BOOL) equipmentValidToAdd:(NSString *)equipmentKey inContext:(NSString *)context;	// Actual test if equipment satisfies validation criteria.
 - (BOOL) equipmentValidToAdd:(NSString *)equipmentKey whileLoading:(BOOL)loading inContext:(NSString *)context;
 - (BOOL) addEquipmentItem:(NSString *)equipmentKey inContext:(NSString *)context;

--- a/src/Core/Entities/ShipEntity.m
+++ b/src/Core/Entities/ShipEntity.m
@@ -3221,6 +3221,23 @@ ShipEntity* doOctreesCollide(ShipEntity* prime, ShipEntity* other)
 	return YES;
 }
 
+- (BOOL) canAddEquipmentForSale:(NSString *)equipmentKey /*inContext:(NSString *)context*/
+{
+	
+	// If equipment is a sell configuration for something aboard, allow it to pass.
+	/*if ([equipmentKey hasSuffix:@"_SELL"])
+	{
+		if ([self hasEquipmentItem:[equipmentKey substringToIndex:[equipmentKey length] - [@"_SELL" length]]])  return YES;
+	}*/
+	
+	OOEquipmentType *eqType = [OOEquipmentType equipmentTypeWithIdentifier:equipmentKey];
+	
+	// If the equipment is already installed and can be sold, it's okay. (TODO: Make it work with multiple same items.)
+	if (![eqType canCarryMultiple] && [self hasEquipmentItem:equipmentKey] && [eqType canBeSold])  return YES;
+
+	return NO;
+}
+
 
 - (OOWeaponFacingSet) weaponFacings
 {

--- a/src/Core/GuiDisplayGen.h
+++ b/src/Core/GuiDisplayGen.h
@@ -75,6 +75,7 @@ static NSString * const kGuiEquipmentUnavailableColor	= @"equipment_unavailable_
 static NSString * const kGuiEquipmentScrollColor	= @"equipment_scroll_color";
 static NSString * const kGuiEquipmentOptionColor	= @"equipment_option_color";
 static NSString * const kGuiEquipmentRepairColor	= @"equipment_repair_color";
+static NSString * const kGuiEquipmentSellColor		= @"equipment_sell_color";
 static NSString * const kGuiEquipmentDescriptionColor	= @"equipment_description_color";
 static NSString * const kGuiEquipmentLaserColor		= @"equipment_laser_color";
 static NSString * const kGuiEquipmentLaserFittedColor	= @"equipment_laser_fitted_color";

--- a/src/Core/OOEquipmentType.h
+++ b/src/Core/OOEquipmentType.h
@@ -57,6 +57,7 @@ SOFTWARE.
 							_isAvailableToNPCs: 1,
 							_fastAffinityA: 1,
 							_fastAffinityB: 1,
+							_canBeSold: 1,
 							_canCarryMultiple: 1;
 	NSUInteger				_installTime;
 	NSUInteger				_repairTime;
@@ -89,6 +90,7 @@ SOFTWARE.
 
 - (NSString *) identifier;
 - (NSString *) damagedIdentifier;
+- (NSString *) sellIdentifier;
 - (NSString *) name;			// localized
 - (NSString *) descriptiveText;	// localized
 - (OOTechLevelID) techLevel;
@@ -107,6 +109,7 @@ SOFTWARE.
 - (BOOL) isPortableBetweenShips;
 
 - (BOOL) canCarryMultiple;
+- (BOOL) canBeSold;
 - (GLfloat) damageProbability;
 - (BOOL) canBeDamaged;
 - (BOOL) isVisible;				// Visible in UI?

--- a/src/Core/OOEquipmentType.m
+++ b/src/Core/OOEquipmentType.m
@@ -227,6 +227,8 @@ static NSDictionary		*sMissilesRegistry = nil;
 			_isVisible = [extra oo_boolForKey:@"visible" defaultValue:_isVisible];
 			_canCarryMultiple = [extra oo_boolForKey:@"can_carry_multiple" defaultValue:NO];
 			
+			_canBeSold = [extra oo_boolForKey:@"can_be_sold" defaultValue:_canBeSold];
+			
 			_requiredCargoSpace = [extra oo_unsignedIntForKey:@"requires_cargo_space" defaultValue:_requiredCargoSpace];
 
 			_installTime = [extra oo_unsignedIntForKey:@"installation_time" defaultValue:0];
@@ -362,6 +364,11 @@ static NSDictionary		*sMissilesRegistry = nil;
 	return [_identifier stringByAppendingString:@"_DAMAGED"];
 }
 
+- (NSString *) sellIdentifier
+{
+	return [_identifier stringByAppendingString:@"_SELL"];
+}
+
 
 - (NSString *) name
 {
@@ -469,6 +476,11 @@ static NSDictionary		*sMissilesRegistry = nil;
 	return _canCarryMultiple;
 }
 
+
+- (BOOL) canBeSold
+{
+	return _canBeSold;
+}
 
 - (GLfloat) damageProbability 
 {


### PR DESCRIPTION
First things first. I hate git (the tool). This should be all files I have edited, but I struggled quite hard just to reach this point, where I can commit this proposal. On the way I lost the ability to compile the project to see if everything works. I did compile a running version before I tried to upload it to github and it worked quite well ( or I wouldn't have decided to upload it.)

This changes add a new possible key for an item to equipment.plist: "can_be_sold"
The new method in ShipEntity.m "canAddEquipmentForSale" checks if an item has this new key, if its value is "true" and if this item already has been installed.
Another check has been added to the equipment purchase GUI in PlayerEntity.m , that uses "canAddEquipmentForSale", to see, if it's installed and has the new key. In this case the item's identifier key will be left to be listed in the purchase screen, but later on its appearance changes. The textcolor of the entry changes to orange, much like the "repair option", the string "Sell: " is added to the title and other disclaimers are added to the description. Further the behaviour, when selected, changes to refunding the price and removing that item from the ship.

Pro:
- OXP developers get a simple way to add a sell option.
- This sell option provides a unified look for all Items that use it.
- The look of the sell option differs from regular purchase list entries, making them easier to spot and more distinguishable from other entries.

Contra:
- The sell option, as simple as it is, is quite inflexible at this point. If an OXP developer wants to do something different to sell an Item (different refund value, diff. techlevel, edited description texts, dependences to other equipment). In this case she/he has to fall back on using the old methods. Those methods don't provide the different "Sell Option" color.

There are two ways to get rid of that contra point.
- Adding more Keys to the item, that contain alternative data like techlevel or refund value. This may be implemented much like the "weapon_info" key. A "sell_info" key.
- The second way is kinda cheap, but maybe the better solution. Adding another key that let developers change the textcolor of the purchase entry. This way they can mimic the design of the sell option (and as bonus of the repair option too) and have all the same possibilities as before. Choosing the color wisely should be left in the devel.'s hands. (Screwing around with colors just shows bad taste of the devel. and of the OXP and not of the game as a whole.) The colors can be limited to the colors of the repair and sell options, too. "entry_color" = "blue"; (red, orange, aso. or standard_color, repair_color, sell_color).

In any case a sell option in any form should left in-code, to give an example how an entry for selling should look like. Ohh, and my changes aren't usable on items, that can be installed multiple times.