### PR TITLE
Sell option.

### DIFF
--- a/Resources/Config/descriptions.plist
+++ b/Resources/Config/descriptions.plist
@@ -1656,9 +1656,12 @@
 	"equip-cash-value"				= "Cash: [credits|dcr].";
 	"equip-no-equipment-available-for-purchase" = "No equipment available for purchase.";
 	"equip-repair-@"				= " Repair:%@";
+	"equip-sell-@"					= " Sell:%@";
+	"upgradeinfo-@-price-is-for-refunding" = "%@ (Price will be refunded for the existing system).";
 	"upgradeinfo-@-price-is-for-repairing" = "%@ (Price is for repairing the existing system).";
 	"@-will-replace-other-energy"	="%@ (The installed energy recharge unit will be removed and sold for scrap).";
 	"upgradeinfo-@-weight-d-of-equipment" = "%@\nTakes up %dt of cargo space.";
+	"upgradeinfo-@-frees-weight-d-of-equipment" = "%@\nFrees up %dt of cargo space.";
 	"forward-facing-string"			= " Forward ";
 	"aft-facing-string"				= " Aft ";
 	"port-facing-string"			= " Port ";

--- a/src/Core/Entities/PlayerEntity.h
+++ b/src/Core/Entities/PlayerEntity.h
@@ -1033,6 +1033,9 @@ typedef enum
 
 - (OOSpeechSettings) isSpeechOn;
 
+- (BOOL) isEquipmentSellOption:(NSString *)equipmentKey;
+- (BOOL) canAddEquipmentSellOption:(NSString *)equipmentKey;
+
 - (void) addEquipmentFromCollection:(id)equipment;	// equipment may be an array, a set, a dictionary whose values are all YES, or a string.
  
 - (void) getFined;

--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -9731,7 +9731,7 @@ static NSString *last_outfitting_key=nil;
 	
 	price *= priceFactor;  // increased prices at some stations
 	
-	if (price > credits)
+	if (price > credits && ![self isEquipmentSellOption:eqKey])
 	{
 		return NO;
 	}

--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -8677,7 +8677,6 @@ static NSString *last_outfitting_key=nil;
 		{
 			if (techlevel < minTechLevel) isOK = NO;
 			if (![self canAddEquipment:eqKey inContext:@"purchase"]) isOK = NO;
-			//if ([self isEquipmentSellOption:eqKey] && ![canAddEquipmentSellOption]) isOK = NO;
 			if (available_facings == 0 && [eqType isPrimaryWeapon]) isOK = NO;
 			if (isOK)  [equipmentAllowed addObject:eqKey];
 		}
@@ -8807,6 +8806,7 @@ static NSString *last_outfitting_key=nil;
 				// is this item a sell option?
 				if ([self isEquipmentSellOption:eqKey])
 				{
+					//desc = [NSString stringWithFormat:DESC(@"equip-sell-@"), desc]; //Uncomment to add "equip sell" string ("Sell: ") at the beginning to the entry.
 					if (installTime == 0)
 					{
 						installTime = 600 + price;
@@ -9005,7 +9005,7 @@ static NSString *last_outfitting_key=nil;
 				
 				// In case the menu entry is for selling items:
 				if ([self isEquipmentSellOption:eqKey]) {
-					desc = [NSString stringWithFormat:DESC(@"upgradeinfo-@-price-is-for-refunding"), desc];
+					//desc = [NSString stringWithFormat:DESC(@"upgradeinfo-@-price-is-for-refunding"), desc]; //Uncomment to enable "price is for refunding" infotext at the end of the description text.
 					if (weight > 0) desc = [NSString stringWithFormat:DESC(@"upgradeinfo-@-frees-weight-d-of-equipment"), desc, weight];
 				}
 				else if (weight > 0) desc = [NSString stringWithFormat:DESC(@"upgradeinfo-@-weight-d-of-equipment"), desc, weight];
@@ -9928,7 +9928,6 @@ static NSString *last_outfitting_key=nil;
 		[self doTradeIn:tradeIn forPriceFactor:priceFactor];
 		return YES;
 	}
-	
 	
 	if ([self canAddEquipment:eqKey inContext:@"purchase"])
 	{

--- a/src/Core/Entities/ShipEntity.m
+++ b/src/Core/Entities/ShipEntity.m
@@ -3403,7 +3403,6 @@ ShipEntity* doOctreesCollide(ShipEntity* prime, ShipEntity* other)
 	// while loading, we mainly need to catch changes when the installed oxps set has changed since saving. 
 	if ([eqType requiresEmptyPylon] && [self missileCount] >= [self missileCapacity] && !loading)  return NO;
 	if ([eqType  requiresMountedPylon] && [self missileCount] == 0 && !loading)  return NO;
-	if ([self availableCargoSpace] < [eqType requiredCargoSpace] && !validationForDamagedEquipment && !loading)  return NO;
 	if ([eqType requiresEquipment] != nil && ![self hasAllEquipment:[eqType requiresEquipment] includeWeapons:YES whileLoading:loading])  return NO;
 	if ([eqType requiresAnyEquipment] != nil && ![self hasEquipmentItem:[eqType requiresAnyEquipment] includeWeapons:YES whileLoading:loading])  return NO;
 	if ([eqType incompatibleEquipment] != nil && [self hasEquipmentItem:[eqType incompatibleEquipment] includeWeapons:YES whileLoading:loading])  return NO;
@@ -3412,6 +3411,11 @@ ShipEntity* doOctreesCollide(ShipEntity* prime, ShipEntity* other)
 	if ([eqType requiresFreePassengerBerth] && [self passengerCount] >= [self passengerCapacity])  return NO;
 	if ([eqType requiresFullFuel] && [self fuel] < [self fuelCapacity] && !loading)  return NO;
 	if ([eqType requiresNonFullFuel] && [self fuel] >= [self fuelCapacity] && !loading)  return NO;
+	
+	// if the "equipment" is only a standin for a sell option, the weight isn't accually subtracted as it won't be added to the ship. 
+	if (![equipmentKey hasSuffix:@"_SELL"]) {
+		if ([self availableCargoSpace] < [eqType requiredCargoSpace] && !validationForDamagedEquipment && !loading)  return NO;
+	}
 
 	if (!loading)
 	{

--- a/src/Core/GuiDisplayGen.h
+++ b/src/Core/GuiDisplayGen.h
@@ -75,6 +75,7 @@ static NSString * const kGuiEquipmentUnavailableColor	= @"equipment_unavailable_
 static NSString * const kGuiEquipmentScrollColor	= @"equipment_scroll_color";
 static NSString * const kGuiEquipmentOptionColor	= @"equipment_option_color";
 static NSString * const kGuiEquipmentRepairColor	= @"equipment_repair_color";
+static NSString * const kGuiEquipmentSellColor		= @"equipment_sell_color";
 static NSString * const kGuiEquipmentDescriptionColor	= @"equipment_description_color";
 static NSString * const kGuiEquipmentLaserColor		= @"equipment_laser_color";
 static NSString * const kGuiEquipmentLaserFittedColor	= @"equipment_laser_fitted_color";


### PR DESCRIPTION
Equipments with identifiers ending with the "_SELL" suffix get a special treatment as "sell options".
This different treatment includes:
- Different textcolor in the equipment purchase menu (similar to the already implemented "repair options")
- Price values are added to the player account instead of being subtracted.
- {Price value}-{current player credits} checkback is ignored for "sell options"(, as the price value is added).
- {Weight value}-{current free cargo space} checkback is ignored for "sell options"(, as that "sale standin" item should be removed directly after it has been awarded it to the ship. (At this point it is the responsibility of the OXP developers to remove it by script at once. This might be a source for bugs, though it worked fine in tests.)
- A given weight value in "sell options" is being used to create a "cargo space will be freed by X tons" message at the end of the description.

The current way for OXP developers to create a selling entry in the purchase menu, is to create standin items, holding the description text and linking to a script that will remove itself and the "sold" items and maybe even refunding credits. This method has proven to be powerful enough to lead to satisfying results, but it has shortcomings.
- Sale entries don't stand out as much as the fine repair option. That's a shame. :) 
- The sale entry's price will always be subtracted first, what makes a satisfiable presentation of refunded credits difficult.

The changes I propose enables developers to create distinguishable "Sale" entries and still using the old method.
