### PR TITLE
Proposed fix for issue #176 (Cache problems with rescaled models).

### DIFF
--- a/Resources/Config/logcontrol.plist
+++ b/Resources/Config/logcontrol.plist
@@ -184,6 +184,7 @@
 	mesh.load.cached						= inherit;
 	mesh.load.uncached						= inherit;
 	mesh.load.octree.size					= no;
+	mesh.load.octreeCached					= inherit;
 	
 	mesh.load.error							= $error;
 	mesh.load.error.badCacheData			= inherit;

--- a/src/Core/Entities/OOEntityWithDrawable.h
+++ b/src/Core/Entities/OOEntityWithDrawable.h
@@ -32,6 +32,7 @@ MA 02110-1301, USA.
 @protocol OOSubEntity
 
 - (void) rescaleBy:(GLfloat)factor;
+- (void) rescaleBy:(GLfloat)factor writeToCache:(BOOL)writeToCache;
 
 // Separate drawing path for subentities of ships.
 - (void) drawSubEntityImmediate:(bool)immediate translucent:(bool)translucent;

--- a/src/Core/Entities/OOExhaustPlumeEntity.m
+++ b/src/Core/Entities/OOExhaustPlumeEntity.m
@@ -622,6 +622,13 @@ static GLfloat pA[6] = { 0.01, 0.0, 2.0, 4.0, 6.0, 10.0 }; // phase adjustments
 }
 
 
+- (void) rescaleBy:(GLfloat)factor writeToCache:(BOOL)writeToCache
+{
+	/* Do nothing; this is only needed because of OOEntityWithDrawable
+	   implementation requirements */
+}
+
+
 - (OOTexture *) texture
 {
 	return [OOExhaustPlumeEntity plumeTexture];

--- a/src/Core/Entities/OOFlasherEntity.m
+++ b/src/Core/Entities/OOFlasherEntity.m
@@ -234,6 +234,13 @@ MA 02110-1301, USA.
 	[self setDiameter:[self diameter] * factor];
 }
 
+
+- (void) rescaleBy:(GLfloat)factor writeToCache:(BOOL)writeToCache
+{
+	/* Do nothing; this is only needed because of OOEntityWithDrawable
+	   implementation requirements */
+}
+
 @end
 
 

--- a/src/Core/Entities/OOVisualEffectEntity.m
+++ b/src/Core/Entities/OOVisualEffectEntity.m
@@ -424,6 +424,13 @@ MA 02110-1301, USA.
 }
 
 
+- (void) rescaleBy:(GLfloat)factor writeToCache:(BOOL)writeToCache
+{
+	/* Do nothing; this is only needed because of OOEntityWithDrawable
+	   implementation requirements */
+}
+
+
 - (GLfloat) scaleMax
 {
 	GLfloat scale = 1.0;

--- a/src/Core/Entities/ShipEntity.m
+++ b/src/Core/Entities/ShipEntity.m
@@ -138,6 +138,7 @@ static GLfloat calcFuelChargeRate (GLfloat myMass)
 #endif
 
 - (void) rescaleBy:(GLfloat)factor;
+- (void) rescaleBy:(GLfloat)factor writeToCache:(BOOL)writeToCache;
 
 - (BOOL) setUpOneSubentity:(NSDictionary *) subentDict;
 - (BOOL) setUpOneFlasher:(NSDictionary *) subentDict;
@@ -396,7 +397,8 @@ static ShipEntity *doOctreesCollide(ShipEntity *prime, ShipEntity *other);
 							 smooth:[shipDict oo_boolForKey:@"smooth" defaultValue:NO]
 					   shaderMacros:OODefaultShipShaderMacros()
 					   shaderBindingTarget:self
-						scaleFactor:_scaleFactor];
+						scaleFactor:_scaleFactor
+					 cacheWriteable:YES];
 
 		if (mesh == nil)  return NO;
 		[self setMesh:mesh];
@@ -8995,6 +8997,12 @@ NSComparisonResult ComparePlanetsBySurfaceDistance(id i1, id i2, void* context)
 
 - (void) rescaleBy:(GLfloat)factor
 {
+	[self rescaleBy:factor writeToCache:YES];
+}
+
+
+- (void) rescaleBy:(GLfloat)factor writeToCache:(BOOL)writeToCache
+{
 	_scaleFactor *= factor;
 	OOMesh *mesh = nil;
 
@@ -9009,7 +9017,8 @@ NSComparisonResult ComparePlanetsBySurfaceDistance(id i1, id i2, void* context)
 							 smooth:[shipDict oo_boolForKey:@"smooth" defaultValue:NO]
 					   shaderMacros:OODefaultShipShaderMacros()
 					   shaderBindingTarget:self
-						scaleFactor:factor];
+						scaleFactor:factor
+					 cacheWriteable:writeToCache];
 
 		if (mesh == nil)  return;
 		[self setMesh:mesh];
@@ -9020,7 +9029,7 @@ NSComparisonResult ComparePlanetsBySurfaceDistance(id i1, id i2, void* context)
 	foreach (se, [self subEntities])
 	{
 		[se setPosition:HPvector_multiply_scalar([se position], factor)];
-		[se rescaleBy:factor];
+		[se rescaleBy:factor writeToCache:writeToCache];
 	}
 	
 	// rescale mass

--- a/src/Core/OOCacheManager.m
+++ b/src/Core/OOCacheManager.m
@@ -73,7 +73,7 @@ static NSString * const kCacheKeyCaches						= @"caches";
 enum
 {
 	kEndianTagValue			= 0x0123456789ABCDEFULL,
-	kFormatVersionValue		= 218
+	kFormatVersionValue		= 219
 };
 
 

--- a/src/Core/OOMesh.h
+++ b/src/Core/OOMesh.h
@@ -98,6 +98,8 @@ typedef struct
 	OOMeshFaceCount			faceCount;
 	
 	NSString				*baseFile;
+	NSString				*baseFileOctreeCacheRef;
+	BOOL					_cacheWriteable;
 	
 	Vector					*_vertices;
 	Vector					*_normals;
@@ -155,7 +157,8 @@ typedef struct
 					   smooth:(BOOL)smooth
 				 shaderMacros:(NSDictionary *)macros
 		  shaderBindingTarget:(id<OOWeakReferenceSupport>)object
-				  scaleFactor:(float)factor;
+				  scaleFactor:(float)factor
+			   cacheWriteable:(BOOL)cacheWriteable;
 
 
 + (OOMaterial *) placeholderMaterial;

--- a/src/Core/Universe.m
+++ b/src/Core/Universe.m
@@ -5492,7 +5492,7 @@ static BOOL MaintainLinkedLists(Universe *uni)
 		GLfloat expected_mass = 0.1f * [ship mass] * (0.75 + 0.5 * randf());
 		GLfloat wreck_mass = [wreck mass];
 		GLfloat scale_factor = powf(expected_mass / wreck_mass, 0.33333333f) * scale;	// cube root of volume ratio
-		[wreck rescaleBy: scale_factor];
+		[wreck rescaleBy:scale_factor writeToCache:NO];
 
 		[wreck setPosition:rpos];
 


### PR DESCRIPTION
This is the proposed resolution for the cache issues related to rescaling models (#176). Given that the cache is a high-risk area, I'd rather give a chance for the proposal to be reviewed first, rather than merging staight away.

As per this PR, separate entries are now inserted in the cache for models of different scale factors, applying both to mesh and octree data. Before this patch, octree data was entered in the cache for only one scale factor and subsequent calls for creation at other scale factors would result in a model that had collision detection and volume calculation issues. This could have very well been the cause of some weird bugs reported rarely in the past, whereby a player ship would be apparently hit by "something" and get ejected at excessive velocities towards a random direction.

The octree data is now tagged as "modelname.dat-XX.YYY", where XX.YYY is the scale factor referring to that particular model. Mesh caches were already getting tagged as separate entries for different scale factors, so now we bring also the octree tagging to work in the same manner. This resolves the main, quite serious, issue.

This PR resolves also a secondary issue, which is the filling up of the cache file with irrelevant data about randomly scaled, internally generated wreckage models. This kind of random internal rescaling happens only for wreckages at this point. The solution here was to implement an alternative rescaling method in ShipEntity, where a boolean parameter is passed for decdiding whether to write the result of the generated model to cache or not. With this, only wreckage models of scale 1.000 are written in the cache, unless specifically requested otherwise by means of script, debug console commands etc.. There is no reason to write data about e.g. wreck1,dat-1.803, when this model is randomly rescaled and chances of it being requested again any time soon are extremely slim. It's probably best to leave room for other objects, with better hit chances and it is certainly cleaner. This fix applies to both octree and mesh data.

I would also note that, before going with this solution, I had also looked at rescaling octrees using the already provided methods, However, this did not work out very well. With an octree at scale 1:1 in the cache, requesting a rescaled octree to 64 x original for example, is not the same as generating an octree for a 64x rescaled model from scratch.

We know that the fix outlined in this PR works on Windows, as a test build has been circulated in the forums and the initial reports seem to indicate good functionality and no performance hits. If this could be tested across the three supported platforms, it would be great.