### PR TITLE
Fix compile problems with gcc version 5

### DIFF
--- a/src/Core/Debug/OODebugMonitor.m
+++ b/src/Core/Debug/OODebugMonitor.m
@@ -508,7 +508,7 @@ typedef struct
 
 - (void) dumpMemoryStatistics
 {
-	OOLog(@"debug.memStats", @"Memory statistics:");
+	OOLog(@"debug.memStats", @"%@", @"Memory statistics:");
 	OOLogIndent();
 	
 	//	Get texture retain counts before the entity dumper starts messing with them.

--- a/src/Core/Debug/OODebugTCPConsoleClient.m
+++ b/src/Core/Debug/OODebugTCPConsoleClient.m
@@ -393,7 +393,7 @@ noteChangedConfigrationValue:(in id)newValue
 	*/
 	if (![self sendBytes:&header count:sizeof header])
 	{
-		OOLog(@"debugTCP.send.warning", @"Error sending packet header, retrying.");
+		OOLog(@"debugTCP.send.warning", @"%@", @"Error sending packet header, retrying.");
 		// wait 8 milliseconds, resend the header
 		[[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:.008]];
 		if (![self sendBytes:&header count:sizeof header])
@@ -410,7 +410,7 @@ noteChangedConfigrationValue:(in id)newValue
 	
 	if(sentOK && ![self sendBytes:bytes count:count])
 	{
-		OOLog(@"debugTCP.send.warning", @"Error sending packet body, retrying.");
+		OOLog(@"debugTCP.send.warning", @"%@", @"Error sending packet body, retrying.");
 		// wait 8 milliseconds, try again.
 		[[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:.008]];
 		if(![self sendBytes:bytes count:count])
@@ -667,7 +667,7 @@ noteChangedConfigrationValue:(in id)newValue
 	}
 	else
 	{
-		OOLog(@"debugTCP.disconnect", @"Debug console not connected.");	
+		OOLog(@"debugTCP.disconnect", @"%@", @"Debug console not connected.");	
 	}
 	
 #if 0

--- a/src/Core/Entities/OOSunEntity.m
+++ b/src/Core/Entities/OOSunEntity.m
@@ -234,7 +234,7 @@ MA 02110-1301, USA.
 {
 	if (gDebugFlags & DEBUG_COLLISIONS)
 	{
-		OOLog(@"sun.collide", @"SUN Collision!");
+		OOLog(@"sun.collide", @"%@", @"SUN Collision!");
 	}
 	
 	return [super checkCloseCollisionWith:other];

--- a/src/Core/Entities/PlayerEntityLoadSave.m
+++ b/src/Core/Entities/PlayerEntityLoadSave.m
@@ -333,7 +333,7 @@ static uint16_t PersonalityForCommanderDict(NSDictionary *dict);
 	NSString *file = [scenario oo_stringForKey:@"file" defaultValue:nil];
 	if (file == nil) 
 	{
-		OOLog(@"scenario.init.error",@"No file entry found for scenario");
+		OOLog(@"scenario.init.error", @"%@", @"No file entry found for scenario");
 		return NO;
 	}
 	NSString *path = [ResourceManager pathForFileNamed:file inFolder:@"Scenarios"];
@@ -616,7 +616,7 @@ static uint16_t PersonalityForCommanderDict(NSDictionary *dict);
 	
 	if (loadedOK)
 	{
-		OOLog(@"load.progress",@"Reading file");
+		OOLog(@"load.progress", @"%@", @"Reading file");
 		fileDic = OODictionaryFromFile(fileToOpen);
 		if (fileDic == nil)
 		{
@@ -627,7 +627,7 @@ static uint16_t PersonalityForCommanderDict(NSDictionary *dict);
 
 	if (loadedOK)
 	{
-		OOLog(@"load.progress",@"Restricting scenario");
+		OOLog(@"load.progress", @"%@", @"Restricting scenario");
 		NSString *scenarioRestrict = [fileDic oo_stringForKey:@"scenario_restriction" defaultValue:nil];
 		if (scenarioRestrict == nil)
 		{
@@ -653,7 +653,7 @@ static uint16_t PersonalityForCommanderDict(NSDictionary *dict);
 
 	if (loadedOK)
 	{
-		OOLog(@"load.progress",@"Creating player ship");
+		OOLog(@"load.progress", @"%@", @"Creating player ship");
 		// Check that player ship exists
 		NSString		*shipKey = nil;
 		NSDictionary	*shipDict = nil;
@@ -671,7 +671,7 @@ static uint16_t PersonalityForCommanderDict(NSDictionary *dict);
 	
 	if (loadedOK)
 	{
-		OOLog(@"load.progress",@"Initialising player entity");
+		OOLog(@"load.progress", @"%@", @"Initialising player entity");
 		if (![self setUpAndConfirmOK:YES saveGame:YES])
 		{
 			fail_reason = DESC(@"loadfailed-could-not-reset-javascript");
@@ -681,7 +681,7 @@ static uint16_t PersonalityForCommanderDict(NSDictionary *dict);
 	
 	if (loadedOK)
 	{
-		OOLog(@"load.progress",@"Loading commander data");
+		OOLog(@"load.progress", @"%@", @"Loading commander data");
 		if (![self setCommanderDataFromDictionary:fileDic])
 		{
 			// this could still be a reset js issue, if switching from strict / unrestricted
@@ -693,7 +693,7 @@ static uint16_t PersonalityForCommanderDict(NSDictionary *dict);
 	
 	if (loadedOK)
 	{
-		OOLog(@"load.progress",@"Recording save path");
+		OOLog(@"load.progress", @"%@", @"Recording save path");
 		if (!asNew)
 		{
 			[save_path autorelease];
@@ -714,7 +714,7 @@ static uint16_t PersonalityForCommanderDict(NSDictionary *dict);
 		return NO;
 	}
 	
-	OOLog(@"load.progress",@"Creating system");
+	OOLog(@"load.progress", @"%@", @"Creating system");
 	[UNIVERSE setTimeAccelerationFactor:TIME_ACCELERATION_FACTOR_DEFAULT];
 	[UNIVERSE setSystemTo:system_id];
 	[UNIVERSE removeAllEntitiesExceptPlayer];
@@ -722,7 +722,7 @@ static uint16_t PersonalityForCommanderDict(NSDictionary *dict);
 	[UNIVERSE setUpSpace];
 	[UNIVERSE setAutoSaveNow:NO];
 	
-	OOLog(@"load.progress",@"Resetting player flight variables");
+	OOLog(@"load.progress",@"%@", @"Resetting player flight variables");
 	[self setDockedAtMainStation];
 	StationEntity *dockedStation = [self dockedStation];
 	
@@ -744,7 +744,7 @@ static uint16_t PersonalityForCommanderDict(NSDictionary *dict);
 	
 	[self setEntityPersonalityInt:PersonalityForCommanderDict(fileDic)];
 	
-	OOLog(@"load.progress",@"Loading system market");
+	OOLog(@"load.progress", @"%@", @"Loading system market");
 	// dockedStation is always the main station at this point;
 	// "localMarket" save key always refers to the main station (system) market
 	NSArray *market = [fileDic oo_arrayForKey:@"localMarket"];
@@ -759,7 +759,7 @@ static uint16_t PersonalityForCommanderDict(NSDictionary *dict);
 
 	[self calculateCurrentCargo];
 	
-	OOLog(@"load.progress",@"Setting scenario key");
+	OOLog(@"load.progress",@"%@", @"Setting scenario key");
 	// set scenario key if the scenario allows saving and has one
 	NSString *scenario = [fileDic oo_stringForKey:@"scenario_key" defaultValue:nil];
 	DESTROY(scenarioKey);
@@ -768,11 +768,11 @@ static uint16_t PersonalityForCommanderDict(NSDictionary *dict);
 		scenarioKey = [scenario retain];
 	}
 
-	OOLog(@"load.progress",@"Starting JS engine");
+	OOLog(@"load.progress",@"%@", @"Starting JS engine");
 	// Remember the savegame target, run js startUp.
 	[self completeSetUpAndSetTarget:NO];
 	// run initial system population
-	OOLog(@"load.progress",@"Populating initial system");
+	OOLog(@"load.progress", @"%@", @"Populating initial system");
 	[UNIVERSE populateNormalSpace];
 
 	// might as well start off with a collected JS environment
@@ -792,14 +792,14 @@ static uint16_t PersonalityForCommanderDict(NSDictionary *dict);
 	// and initialise markets for the secondary stations
 	[UNIVERSE loadStationMarkets:[fileDic oo_arrayForKey:@"station_markets"]];
 
-	OOLog(@"load.progress",@"Completing JS startup");
+	OOLog(@"load.progress", @"%@", @"Completing JS startup");
 	[self startUpComplete];
 
 	[[UNIVERSE gameView] supressKeysUntilKeyUp];
 	gui_screen = GUI_SCREEN_LOAD; // force evaluation of new gui screen on startup
 	[self setGuiToStatusScreen];
 	if (loadedOK) [self doWorldEventUntilMissionScreen:OOJSID("missionScreenOpportunity")];  // trigger missionScreenOpportunity immediately after loading
-	OOLog(@"load.progress",@"Loading complete");
+	OOLog(@"load.progress",@"%@", @"Loading complete");
 	return loadedOK;
 }
 

--- a/src/Core/Entities/ShipEntity.m
+++ b/src/Core/Entities/ShipEntity.m
@@ -9415,7 +9415,7 @@ NSComparisonResult ComparePlanetsBySurfaceDistance(id i1, id i2, void* context)
 			if (isPlayer)
 			{
 	#ifndef NDEBUG
-				OOLog(@"becomeExplosion.suspectedGhost.confirm", @"Ship spotted with isPlayer set when not actually the player.");
+				OOLog(@"becomeExplosion.suspectedGhost.confirm", @"%@", @"Ship spotted with isPlayer set when not actually the player.");
 	#endif
 				isPlayer = NO;
 			}
@@ -14476,7 +14476,7 @@ static BOOL AuthorityPredicate(Entity *entity, void *parameter)
 	
 	if (shipAI != nil && OOLogWillDisplayMessagesInClass(@"dumpState.shipEntity.ai"))
 	{
-		OOLog(@"dumpState.shipEntity.ai", @"AI:");
+		OOLog(@"dumpState.shipEntity.ai", @"%@", @"AI:");
 		OOLogPushIndent();
 		OOLogIndent();
 		@try

--- a/src/Core/Materials/OOShaderProgram.m
+++ b/src/Core/Materials/OOShaderProgram.m
@@ -157,7 +157,7 @@ static NSString *GetGLSLInfoLog(GLhandleARB shaderObject);
 #ifndef NDEBUG
 	if (EXPECT_NOT(sActiveProgram == self))
 	{
-		OOLog(@"shader.dealloc.imbalance", @"***** OOShaderProgram deallocated while active, indicating a retain/release imbalance. Expect imminent crash.");
+		OOLog(@"shader.dealloc.imbalance", @"%@", @"***** OOShaderProgram deallocated while active, indicating a retain/release imbalance. Expect imminent crash.");
 		[OOShaderProgram applyNone];
 	}
 #endif

--- a/src/Core/OOCache.m
+++ b/src/Core/OOCache.m
@@ -704,11 +704,11 @@ static OOCacheNode *TreeSplay(OOCacheNode **root, id<OOCacheComparable> key)
 #ifndef NDEBUG
 		if (node == NULL)
 		{
-			OOLog(@"node.error",@"node is NULL");
+			OOLog(@"node.error", @"%@", @"node is NULL");
 		}
 		else if (node->key == NULL)
 		{
-			OOLog(@"node.error",@"node->key is NULL");
+			OOLog(@"node.error", @"%@", @"node->key is NULL");
 		}
 #endif
 		order = [key compare:node->key];

--- a/src/Core/OOConvertSystemDescriptions.m
+++ b/src/Core/OOConvertSystemDescriptions.m
@@ -57,7 +57,7 @@ void CompileSystemDescriptions(BOOL asXML)
 												   andMerge:NO];
 	if (sysDescDict == nil)
 	{
-		OOLog(@"sysdesc.compile.failed.fileNotFound", @"Could not load a dictionary from sysdesc.plist, ignoring --compile-sysdesc option.");
+		OOLog(@"sysdesc.compile.failed.fileNotFound", @"%@", @"Could not load a dictionary from sysdesc.plist, ignoring --compile-sysdesc option.");
 		return;
 	}
 	
@@ -69,7 +69,7 @@ void CompileSystemDescriptions(BOOL asXML)
 	sysDescArray = OOConvertSystemDescriptionsToArrayFormat(sysDescDict, keyMap);
 	if (sysDescArray == nil)
 	{
-		OOLog(@"sysdesc.compile.failed.conversion", @"Could not convert sysdesc.plist to descriptions.plist format for some reason.");
+		OOLog(@"sysdesc.compile.failed.conversion", @"%@", @"Could not convert sysdesc.plist to descriptions.plist format for some reason.");
 		return;
 	}
 	
@@ -94,11 +94,11 @@ void CompileSystemDescriptions(BOOL asXML)
 	
 	if ([ResourceManager writeDiagnosticData:data toFileNamed:@"sysdesc-compiled.plist"])
 	{
-		OOLog(@"sysdesc.compile.success", @"Wrote translated sysdesc.plist to sysdesc-compiled.plist.");
+		OOLog(@"sysdesc.compile.success", @"%@", @"Wrote translated sysdesc.plist to sysdesc-compiled.plist.");
 	}
 	else
 	{
-		OOLog(@"sysdesc.compile.failed.writeFailure", @"Could not write translated sysdesc.plist to sysdesc-compiled.plist.");
+		OOLog(@"sysdesc.compile.failed.writeFailure", @"%@", @"Could not write translated sysdesc.plist to sysdesc-compiled.plist.");
 	}
 }
 
@@ -121,7 +121,7 @@ void ExportSystemDescriptions(BOOL asXML)
 	sysDescDict = OOConvertSystemDescriptionsToDictionaryFormat(sysDescArray, keyMap);
 	if (sysDescArray == nil)
 	{
-		OOLog(@"sysdesc.export.failed.conversion", @"Could not convert system_description do sysdesc.plist format for some reason.");
+		OOLog(@"sysdesc.export.failed.conversion", @"%@", @"Could not convert system_description do sysdesc.plist format for some reason.");
 		return;
 	}
 	
@@ -144,11 +144,11 @@ void ExportSystemDescriptions(BOOL asXML)
 	
 	if ([ResourceManager writeDiagnosticData:data toFileNamed:@"sysdesc.plist"])
 	{
-		OOLog(@"sysdesc.export.success", @"Wrote translated system_description to sysdesc.plist.");
+		OOLog(@"sysdesc.export.success", @"%@", @"Wrote translated system_description to sysdesc.plist.");
 	}
 	else
 	{
-		OOLog(@"sysdesc.export.failed.writeFailure", @"Could not write translated system_description to sysdesc.plist.");
+		OOLog(@"sysdesc.export.failed.writeFailure", @"%@", @"Could not write translated system_description to sysdesc.plist.");
 	}
 }
 

--- a/src/Core/OOOpenGL.m
+++ b/src/Core/OOOpenGL.m
@@ -261,14 +261,14 @@ void LogOpenGLState(void)
 	
 	OO_ENTER_OPENGL();
 	
-	OOLog(kOOLogOpenGLStateDump, @"OpenGL state dump:");
+	OOLog(kOOLogOpenGLStateDump, @"%@", @"OpenGL state dump:");
 	OOLogIndent();
 	
 	GLDumpMaterialState();
 	GLDumpCullingState();
 	if (glIsEnabled(GL_LIGHTING))
 	{
-		OOLog(kOOLogOpenGLStateDump, @"Lighting: ENABLED");
+		OOLog(kOOLogOpenGLStateDump, @"%@", @"Lighting: ENABLED");
 		for (i = 0; i != 8; ++i)
 		{
 			GLDumpLightState(i);
@@ -276,7 +276,7 @@ void LogOpenGLState(void)
 	}
 	else
 	{
-		OOLog(kOOLogOpenGLStateDump, @"Lighting: disabled");
+		OOLog(kOOLogOpenGLStateDump, @"%@", @"Lighting: disabled");
 	}
 
 	GLDumpFogState();
@@ -346,7 +346,7 @@ static void GLDumpMaterialState(void)
 	
 	OO_ENTER_OPENGL();
 	
-	OOLog(kOOLogOpenGLStateDump, @"Material state:");
+	OOLog(kOOLogOpenGLStateDump, @"%@", @"Material state:");
 	OOLogIndent();
 	
 	OOGL(glGetMaterialfv(GL_FRONT, GL_AMBIENT, color));
@@ -470,7 +470,7 @@ static void GLDumpStateFlags(void)
 #define DUMP_STATE_FLAG(x) OOLog(kOOLogOpenGLStateDump, @ #x ": %@", OOGLFlagToString(glIsEnabled(x)))
 #define DUMP_GET_FLAG(x) do { GLboolean flag; glGetBooleanv(x, &flag); OOLog(kOOLogOpenGLStateDump, @ #x ": %@", OOGLFlagToString(flag)); } while (0)
 	
-	OOLog(kOOLogOpenGLStateDump, @"Selected state flags:");
+	OOLog(kOOLogOpenGLStateDump, @"%@", @"Selected state flags:");
 	OOLogIndent();
 	
 	DUMP_STATE_FLAG(GL_VERTEX_ARRAY);

--- a/src/Core/OOStringExpander.m
+++ b/src/Core/OOStringExpander.m
@@ -301,7 +301,7 @@ static NSString *Expand(OOStringExpansionContext *context, NSString *string, NSU
 		}
 		else if (thisChar == ']')
 		{
-			SyntaxWarning(context, @"strings.expand.warning.unbalancedClosingBracket", @"Unbalanced ] in string.");
+			SyntaxWarning(context, @"strings.expand.warning.unbalancedClosingBracket", @"%@", @"Unbalanced ] in string.");
 		}
 		else if (thisChar == '\\' && context->convertBackslashN)
 		{
@@ -397,7 +397,7 @@ static NSString *ExpandKey(OOStringExpansionContext *context, const unichar *cha
 	// Fail if no balancing bracket.
 	if (EXPECT_NOT(balanceCount != 0))
 	{
-		SyntaxWarning(context, @"strings.expand.warning.unbalancedOpeningBracket", @"Unbalanced [ in string.");
+		SyntaxWarning(context, @"strings.expand.warning.unbalancedOpeningBracket", @"%@", @"Unbalanced [ in string.");
 		return nil;
 	}
 	
@@ -408,7 +408,7 @@ static NSString *ExpandKey(OOStringExpansionContext *context, const unichar *cha
 	
 	if (EXPECT_NOT(keyLength == 0))
 	{
-		SyntaxWarning(context, @"strings.expand.warning.emptyKey", @"Invalid expansion code [] string. (To avoid this message, use %%[%%].)");
+		SyntaxWarning(context, @"strings.expand.warning.emptyKey", @"%@", @"Invalid expansion code [] string. (To avoid this message, use %%[%%].)");
 		return nil;
 	}
 	

--- a/src/Core/OXPVerifier/OOCheckDemoShipsPListVerifierStage.m
+++ b/src/Core/OXPVerifier/OOCheckDemoShipsPListVerifierStage.m
@@ -77,7 +77,7 @@ static NSString * const kStageName	= @"Checking demoships.plist";
 	// Check that it's an array
 	if (![demoshipsPList isKindOfClass:[NSArray class]])
 	{
-		OOLog(@"verifyOXP.demoshipsPList.notArray", @"***** ERROR: demoships.plist is not an array.");
+		OOLog(@"verifyOXP.demoshipsPList.notArray", @"%@", @"***** ERROR: demoships.plist is not an array.");
 		return;
 	}
 	
@@ -92,7 +92,7 @@ static NSString * const kStageName	= @"Checking demoships.plist";
 	// Check that it's a dictionary
 	if (![shipdataPList isKindOfClass:[NSDictionary class]])
 	{
-		OOLog(@"verifyOXP.demoshipsPList.notDict", @"***** ERROR: shipdata.plist is not a dictionary.");
+		OOLog(@"verifyOXP.demoshipsPList.notDict", @"%@", @"***** ERROR: shipdata.plist is not a dictionary.");
 		return;
 	}
 	

--- a/src/Core/OXPVerifier/OOCheckEquipmentPListVerifierStage.m
+++ b/src/Core/OXPVerifier/OOCheckEquipmentPListVerifierStage.m
@@ -78,7 +78,7 @@ static NSString * const kStageName	= @"Checking equipment.plist";
 	// Check that it's an array
 	if (![equipmentPList isKindOfClass:[NSArray class]])
 	{
-		OOLog(@"verifyOXP.equipmentPList.notArray", @"***** ERROR: equipment.plist is not an array.");
+		OOLog(@"verifyOXP.equipmentPList.notArray", @"%@", @"***** ERROR: equipment.plist is not an array.");
 		return;
 	}
 	

--- a/src/Core/OXPVerifier/OOCheckRequiresPListVerifierStage.m
+++ b/src/Core/OXPVerifier/OOCheckRequiresPListVerifierStage.m
@@ -76,7 +76,7 @@ static NSString * const kStageName	= @"Checking requires.plist";
 	// Check that it's a dictionary
 	if (![requiresPList isKindOfClass:[NSDictionary class]])
 	{
-		OOLog(@"verifyOXP.requiresPList.notDict", @"***** ERROR: requires.plist is not a dictionary.");
+		OOLog(@"verifyOXP.requiresPList.notDict", @"%@", @"***** ERROR: requires.plist is not a dictionary.");
 		return;
 	}
 	
@@ -88,7 +88,7 @@ static NSString * const kStageName	= @"Checking requires.plist";
 	if ([actualKeys count] != 0)
 	{
 		
-		OOLog(@"verifyOXP.requiresPList.unknownKeys", @"----- WARNING: requires.plist contains unknown keys. This OXP will not be loaded by this version of Oolite. Unknown keys are: %@.", [[actualKeys allObjects] componentsJoinedByString:@", "]);
+		OOLog(@"verifyOXP.requiresPList.unknownKeys", @"%@", @"----- WARNING: requires.plist contains unknown keys. This OXP will not be loaded by this version of Oolite. Unknown keys are: %@.", [[actualKeys allObjects] componentsJoinedByString:@", "]);
 	}
 	
 	// Sanity check the known keys.
@@ -97,7 +97,7 @@ static NSString * const kStageName	= @"Checking requires.plist";
 	{
 		if (![version isKindOfClass:[NSString class]])
 		{
-			OOLog(@"verifyOXP.requiresPList.badValue", @"***** ERROR: Value for 'version' is not a string.");
+			OOLog(@"verifyOXP.requiresPList.badValue", @"%@", @"***** ERROR: Value for 'version' is not a string.");
 			version = nil;
 		}
 	}
@@ -107,7 +107,7 @@ static NSString * const kStageName	= @"Checking requires.plist";
 	{
 		if (![maxVersion isKindOfClass:[NSString class]])
 		{
-			OOLog(@"verifyOXP.requiresPList.badValue", @"***** ERROR: Value for 'max_version' is not a string.");
+			OOLog(@"verifyOXP.requiresPList.badValue", @"%@", @"***** ERROR: Value for 'max_version' is not a string.");
 			maxVersion = nil;
 		}
 	}
@@ -117,7 +117,7 @@ static NSString * const kStageName	= @"Checking requires.plist";
 		ooVersionComponents = ComponentsFromVersionString([[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"]);
 		if (ooVersionComponents == nil)
 		{
-			OOLog(@"verifyOXP.requiresPList.cantFindOoliteVersion", @"----- WARNING: could not find Oolite's version for requires.plist sanity check.");
+			OOLog(@"verifyOXP.requiresPList.cantFindOoliteVersion", @"%@", @"----- WARNING: could not find Oolite's version for requires.plist sanity check.");
 		}
 		if (version != nil)
 		{

--- a/src/Core/OXPVerifier/OOCheckShipDataPListVerifierStage.m
+++ b/src/Core/OXPVerifier/OOCheckShipDataPListVerifierStage.m
@@ -115,7 +115,7 @@ static NSString * const kStageName	= @"Checking shipdata.plist";
 	// Check that it's a dictionary
 	if (![_shipdataPList isKindOfClass:[NSDictionary class]])
 	{
-		OOLog(@"verifyOXP.shipdataPList.notDict", @"***** ERROR: shipdata.plist is not a dictionary.");
+		OOLog(@"verifyOXP.shipdataPList.notDict", @"%@", @"***** ERROR: shipdata.plist is not a dictionary.");
 		return;
 	}
 	

--- a/src/Core/OXPVerifier/OOFileScannerVerifierStage.m
+++ b/src/Core/OXPVerifier/OOFileScannerVerifierStage.m
@@ -712,7 +712,7 @@ static BOOL CheckNameConflict(NSString *lcName, NSDictionary *directoryCases, NS
 
 - (void)run
 {
-	OOLog(@"verifyOXP.unusedFiles.unimplemented", @"TODO: implement unused files check.");
+	OOLog(@"verifyOXP.unusedFiles.unimplemented", @"%@", @"TODO: implement unused files check.");
 }
 
 

--- a/src/Core/OXPVerifier/OOModelVerifierStage.m
+++ b/src/Core/OXPVerifier/OOModelVerifierStage.m
@@ -102,7 +102,7 @@ static id NSNULL = nil;
 	NSDictionary				*materials = nil,
 								*shaders = nil;
 	
-	OOLog(@"verifyOXP.models.unimplemented", @"TODO: implement model verifier.");
+	OOLog(@"verifyOXP.models.unimplemented", @"%@", @"TODO: implement model verifier.");
 	
 	for (nameEnum = [_modelsToCheck objectEnumerator]; (info = [nameEnum nextObject]); )
 	{

--- a/src/Core/OXPVerifier/OOOXPVerifier.m
+++ b/src/Core/OXPVerifier/OOOXPVerifier.m
@@ -261,7 +261,7 @@ static void OpenLogFile(NSString *name);
 	if (_verifierPList == nil ||
 		_basePath == nil)
 	{
-		OOLog(@"verifyOXP.setup.failed", @"***** ERROR: failed to set up OXP verifier.");
+		OOLog(@"verifyOXP.setup.failed", @"%@", @"***** ERROR: failed to set up OXP verifier.");
 		[self release];
 		return nil;
 	}
@@ -297,7 +297,7 @@ static void OpenLogFile(NSString *name);
 	[self runStages];
 	
 	NoteVerificationStage(_displayName, @"");
-	OOLog(@"verifyOXP.done", @"OXP verification complete.");
+	OOLog(@"verifyOXP.done", @"%@", @"OXP verification complete.");
 	
 	OpenLogFile(_displayName);
 }
@@ -543,7 +543,7 @@ static void OpenLogFile(NSString *name);
 	
 	if ([_waitingStages count] != 0)
 	{
-		OOLog(@"verifyOXP.incomplete", @"Some verifier stages could not be run:");
+		OOLog(@"verifyOXP.incomplete", @"%@", @"Some verifier stages could not be run:");
 		OOLogIndent();
 		for (stageEnum = [_waitingStages objectEnumerator]; (candidateStage = [stageEnum nextObject]); )
 		{

--- a/src/Core/OXPVerifier/OOPListSchemaVerifier.m
+++ b/src/Core/OXPVerifier/OOPListSchemaVerifier.m
@@ -363,7 +363,7 @@ VERIFY_PROTO(DelegatedType);
 	{
 		if (!_badDelegateWarning)
 		{
-			OOLog(@"plistVerifier.badDelegate", @"Property list schema verifier: delegate does not handle delegated types.");
+			OOLog(@"plistVerifier.badDelegate", @"%@", @"Property list schema verifier: delegate does not handle delegated types.");
 			_badDelegateWarning = YES;
 		}
 		result = YES;
@@ -911,7 +911,7 @@ static NSError *Verify_Array(OOPListSchemaVerifier *verifier, id value, NSDictio
 	
 	REQUIRE_TYPE(NSArray, @"array");
 	
-	DebugDump(@"* array");
+	DebugDump(@"%@", @"* array");
 	
 	// Apply count bounds.
 	count = [value count];
@@ -974,7 +974,7 @@ static NSError *Verify_Dictionary(OOPListSchemaVerifier *verifier, id value, NSD
 	
 	REQUIRE_TYPE(NSDictionary, @"dictionary");
 	
-	DebugDump(@"* dictionary");
+	DebugDump(@"%@", @"* dictionary");
 	
 	// Apply count bounds.
 	count = [value count];
@@ -1212,7 +1212,7 @@ static NSError *Verify_OneOf(OOPListSchemaVerifier *verifier, id value, NSDictio
 	NSError					*error;
 	NSMutableDictionary		*errors = nil;
 	
-	DebugDump(@"* oneOf");
+	DebugDump(@"%@", @"* oneOf");
 	
 	options = [params oo_arrayForKey:@"options"];
 	if (options == nil)
@@ -1234,7 +1234,7 @@ static NSError *Verify_OneOf(OOPListSchemaVerifier *verifier, id value, NSDictio
 							error:&error
 							 stop:&stop])
 		{
-			DebugDump(@"> Match.");
+			DebugDump(@"%@", @"> Match.");
 			OK = YES;
 			break;
 		}
@@ -1243,7 +1243,7 @@ static NSError *Verify_OneOf(OOPListSchemaVerifier *verifier, id value, NSDictio
 	
 	if (!OK)
 	{
-		DebugDump(@"! No match.");
+		DebugDump(@"%@", @"! No match.");
 		return ErrorWithProperty(kPListErrorOneOfNoMatch, &keyPath, kErrorsByOptionErrorKey, [errors autorelease], @"No matching type rule could be found.");
 	}
 	
@@ -1259,7 +1259,7 @@ static NSError *Verify_Enumeration(OOPListSchemaVerifier *verifier, id value, NS
 	NSString				*filteredString = nil;
 	NSError					*error = nil;
 	
-	DebugDump(@"* enumeration");
+	DebugDump(@"%@", @"* enumeration");
 	
 	REQUIRE_TYPE(NSString, @"string");
 	

--- a/src/Core/Octree.m
+++ b/src/Core/Octree.m
@@ -435,7 +435,7 @@ static BOOL isHitByLine(const int *octbuffer, unsigned char *collbuffer, int lev
 	
 	collbuffer[level] = 1;	// red
 	
-	OctreeDebugLog(@"----> testing octants...");
+	OctreeDebugLog(@"%@", @"----> testing octants...");
 	
 	int nextLevel = level + octbuffer[level];
 		
@@ -487,7 +487,7 @@ static BOOL isHitByLine(const int *octbuffer, unsigned char *collbuffer, int lev
 	}
 	else
 	{
-		OctreeDebugLog(@"DEBUG Missed!");
+		OctreeDebugLog(@"%@", @"DEBUG Missed!");
 		_hasCollision = hasCollided;
 		return 0.0f;
 	}
@@ -502,19 +502,19 @@ static BOOL isHitByOctree(Octree_details axialDetails,
 
 	if (axialBuffer[0] == 0)
 	{
-		OctreeDebugLog(@"DEBUG Axial octree is empty.");
+		OctreeDebugLog(@"%@", @"DEBUG Axial octree is empty.");
 		return NO;
 	}
 	
 	if (!otherBuffer)
 	{
-		OctreeDebugLog(@"DEBUG Other octree is undefined.");
+		OctreeDebugLog(@"%@", @"DEBUG Other octree is undefined.");
 		return NO;
 	}
 	
 	if (otherBuffer[0] == 0)
 	{
-		OctreeDebugLog(@"DEBUG Other octree is empty.");
+		OctreeDebugLog(@"%@", @"DEBUG Other octree is empty.");
 		return NO;
 	}
 	
@@ -528,7 +528,7 @@ static BOOL isHitByOctree(Octree_details axialDetails,
 			(otherPosition.y + otherRadius < -axialRadius)||(otherPosition.y - otherRadius > axialRadius)||
 			(otherPosition.z + otherRadius < -axialRadius)||(otherPosition.z - otherRadius > axialRadius))
 		{
-			OctreeDebugLog(@"----> Other sphere does not intersect axial cube");
+			OctreeDebugLog(@"%@", @"----> Other sphere does not intersect axial cube");
 			return NO;
 		}
 	}
@@ -540,7 +540,7 @@ static BOOL isHitByOctree(Octree_details axialDetails,
 			(axialPosition.y + axialRadius < -otherRadius)||(axialPosition.y - axialRadius > otherRadius)||
 			(axialPosition.z + axialRadius < -otherRadius)||(axialPosition.z - axialRadius > otherRadius))
 		{
-			OctreeDebugLog(@"----> Axial sphere does not intersect other cube");
+			OctreeDebugLog(@"%@", @"----> Axial sphere does not intersect other cube");
 			return NO;
 		}
 	}
@@ -557,7 +557,7 @@ static BOOL isHitByOctree(Octree_details axialDetails,
 			axialCollisionBuffer[0] = (unsigned char)255;	// mark
 			otherCollisionBuffer[0] = (unsigned char)255;	// mark
 			
-			OctreeDebugLog(@"DEBUG Octrees collide!");
+			OctreeDebugLog(@"%@", @"DEBUG Octrees collide!");
 			return YES;
 		}
 		// the other octree must be decomposed
@@ -565,7 +565,7 @@ static BOOL isHitByOctree(Octree_details axialDetails,
 		// if any of them collides with this octant
 		// then we have a solid collision
 		
-		OctreeDebugLog(@"----> testing other octants...");
+		OctreeDebugLog(@"%@", @"----> testing other octants...");
 		
 		// work out the nearest octant to the axial octree
 		int	nearest_oct = ((otherPosition.x > 0.0)? 0:4)|((otherPosition.y > 0.0)? 0:2)|((otherPosition.z > 0.0)? 0:1);
@@ -601,7 +601,7 @@ static BOOL isHitByOctree(Octree_details axialDetails,
 	// the other octree, if any of them collide
 	// we have a solid collision
 	
-	OctreeDebugLog(@"----> testing axial octants...");
+	OctreeDebugLog(@"%@", @"----> testing axial octants...");
 	
 	// work out the nearest octant to the other octree
 	int	nearest_oct = ((otherPosition.x > 0.0)? 4:0)|((otherPosition.y > 0.0)? 2:0)|((otherPosition.z > 0.0)? 1:0);

--- a/src/Core/ResourceManager.m
+++ b/src/Core/ResourceManager.m
@@ -1032,12 +1032,12 @@ static NSMutableDictionary *sStringCache;
 	// test string
 	if ([sUseAddOns isEqualToString:SCENARIO_OXP_DEFINITION_ALL])
 	{
-		OOLog(@"scenario.check",@"Checked scenario allowances in all state - this is an internal error; please report this");
+		OOLog(@"scenario.check", @"%@", @"Checked scenario allowances in all state - this is an internal error; please report this");
 		return YES;
 	}
 	if ([sUseAddOns isEqualToString:SCENARIO_OXP_DEFINITION_NONE])
 	{
-		OOLog(@"scenario.check",@"Checked scenario allowances in none state - this is an internal error; please report this");
+		OOLog(@"scenario.check", @"%@", @"Checked scenario allowances in none state - this is an internal error; please report this");
 		return NO;
 	}
 #endif

--- a/src/Core/Scripting/OOJSEngineTimeManagement.m
+++ b/src/Core/Scripting/OOJSEngineTimeManagement.m
@@ -324,7 +324,7 @@ void OOJSBeginProfiling(BOOL trace)
 	
 	if (trace)
 	{
-		OOLog(@"script.javaScript.trace", @">>>> Beginning trace.");
+		OOLog(@"script.javaScript.trace", @"%@", @">>>> Beginning trace.");
 		OOLogIndent();
 	}
 }
@@ -358,7 +358,7 @@ OOTimeProfile *OOJSEndProfiling(void)
 	if (sTracing)
 	{
 		OOLogOutdent();
-		OOLog(@"script.javaScript.trace", @"<<<< End of trace.");
+		OOLog(@"script.javaScript.trace", @"%@", @"<<<< End of trace.");
 		sTracing = NO;
 	}
 	

--- a/src/Core/Universe.m
+++ b/src/Core/Universe.m
@@ -255,7 +255,7 @@ static GLfloat	docked_light_specular[4]	= { DOCKED_ILLUM_LEVEL, DOCKED_ILLUM_LEV
 		[NSException raise:NSInternalInconsistencyException format:@"%s: expected only one Universe to exist at a time.", __PRETTY_FUNCTION__];
 	}
 	
-	OO_DEBUG_PROGRESS(@"Universe initWithGameView:");
+	OO_DEBUG_PROGRESS(@"%@", @"Universe initWithGameView:");
 	
 	self = [super init];
 	if (self == nil)  return nil;
@@ -941,7 +941,7 @@ static GLfloat	docked_light_specular[4]	= { DOCKED_ILLUM_LEVEL, DOCKED_ILLUM_LEV
 	
 	sunGoneNova = [systeminfo oo_boolForKey:@"sun_gone_nova" defaultValue:NO];
 	
-	OO_DEBUG_PUSH_PROGRESS(@"setUpSpace - clearSubRegions, sky, dust");
+	OO_DEBUG_PUSH_PROGRESS(@"%@", @"setUpSpace - clearSubRegions, sky, dust");
 	[universeRegion clearSubregions];
 	
 	// fixed entities (part of the graphics system really) come first...
@@ -1024,7 +1024,7 @@ static GLfloat	docked_light_specular[4]	= { DOCKED_ILLUM_LEVEL, DOCKED_ILLUM_LEV
 	
 	// actual entities next...
 	
-	OO_DEBUG_PUSH_PROGRESS(@"setUpSpace - planet");
+	OO_DEBUG_PUSH_PROGRESS(@"%@", @"setUpSpace - planet");
 	a_planet=[self setUpPlanet]; // resets RNG when called
 	double planet_radius = [a_planet radius];
 	OO_DEBUG_POP_PROGRESS();
@@ -1032,7 +1032,7 @@ static GLfloat	docked_light_specular[4]	= { DOCKED_ILLUM_LEVEL, DOCKED_ILLUM_LEV
 	// set the system seed for random number generation
 	seed_for_planet_description(systemSeed);
 	
-	OO_DEBUG_PUSH_PROGRESS(@"setUpSpace - sun");
+	OO_DEBUG_PUSH_PROGRESS(@"%@", @"setUpSpace - sun");
 	/*- space sun -*/
 	double		sun_radius;
 	double		sun_distance;
@@ -1139,7 +1139,7 @@ static GLfloat	docked_light_specular[4]	= { DOCKED_ILLUM_LEVEL, DOCKED_ILLUM_LEV
 	[self setLighting];
 	OO_DEBUG_POP_PROGRESS();
 	
-	OO_DEBUG_PUSH_PROGRESS(@"setUpSpace - main station");
+	OO_DEBUG_PUSH_PROGRESS(@"%@", @"setUpSpace - main station");
 	/*- space station -*/
 	stationPos = [a_planet position];
 
@@ -1226,7 +1226,7 @@ static GLfloat	docked_light_specular[4]	= { DOCKED_ILLUM_LEVEL, DOCKED_ILLUM_LEV
 	OO_DEBUG_POP_PROGRESS();
 	
 	
-	OO_DEBUG_PUSH_PROGRESS(@"setUpSpace - populate from wormholes");
+	OO_DEBUG_PUSH_PROGRESS(@"%@", @"setUpSpace - populate from wormholes");
 	[self populateSpaceFromActiveWormholes];
 	OO_DEBUG_POP_PROGRESS();
 
@@ -1243,7 +1243,7 @@ static GLfloat	docked_light_specular[4]	= { DOCKED_ILLUM_LEVEL, DOCKED_ILLUM_LEV
 	// check for nova
 	if (sunGoneNova)
 	{
-	 	OO_DEBUG_PUSH_PROGRESS(@"setUpSpace - post-nova");
+	 	OO_DEBUG_PUSH_PROGRESS(@"%@", @"setUpSpace - post-nova");
 		
 	 	HPVector v0 = make_HPvector(0,0,34567.89);
 	 	double min_safe_dist2 = 6000000.0 * 6000000.0;
@@ -1263,7 +1263,7 @@ static GLfloat	docked_light_specular[4]	= { DOCKED_ILLUM_LEVEL, DOCKED_ILLUM_LEV
 	 	cachedStation = nil;	
 	}
 
-	OO_DEBUG_PUSH_PROGRESS(@"setUpSpace - populate from hyperpoint");
+	OO_DEBUG_PUSH_PROGRESS(@"%@", @"setUpSpace - populate from hyperpoint");
 //	[self populateSpaceFromHyperPoint:witchPos toPlanetPosition: a_planet->position andSunPosition: a_sun->position];
 	[self clearSystemPopulator];
 
@@ -1288,7 +1288,7 @@ static GLfloat	docked_light_specular[4]	= { DOCKED_ILLUM_LEVEL, DOCKED_ILLUM_LEV
 		OOStandardsDeprecated([NSString stringWithFormat:@"The script_actions system info key is deprecated for %@.",[self getSystemName:systemID]]);
 		if (!OOEnforceStandards()) 
 		{
-			OO_DEBUG_PUSH_PROGRESS(@"setUpSpace - legacy script_actions");
+			OO_DEBUG_PUSH_PROGRESS(@"%@", @"setUpSpace - legacy script_actions");
 			[PLAYER runUnsanitizedScriptActions:script_actions
 							  allowingAIMethods:NO
 								withContextName:@"<system script_actions>"
@@ -4855,7 +4855,7 @@ static BOOL MaintainLinkedLists(Universe *uni)
 			OOExtraLog(kOOLogEntityVerificationError, @"Broken x_previous %@ list (%d) ***", uni->x_list_start, n);
 			if (result)
 			{
-				OOExtraLog(kOOLogEntityVerificationRebuild, @"REBUILDING x_previous list from x_next list");
+				OOExtraLog(kOOLogEntityVerificationRebuild, @"%@", @"REBUILDING x_previous list from x_next list");
 				checkEnt = uni->x_list_start;
 				checkEnt->x_previous = nil;
 				while (checkEnt->x_next)
@@ -4888,7 +4888,7 @@ static BOOL MaintainLinkedLists(Universe *uni)
 			OOExtraLog(kOOLogEntityVerificationError, @"Broken y_previous %@ list (%d) ***", uni->y_list_start, n);
 			if (result)
 			{
-				OOExtraLog(kOOLogEntityVerificationRebuild, @"REBUILDING y_previous list from y_next list");
+				OOExtraLog(kOOLogEntityVerificationRebuild, @"%@", @"REBUILDING y_previous list from y_next list");
 				checkEnt = uni->y_list_start;
 				checkEnt->y_previous = nil;
 				while (checkEnt->y_next)
@@ -4921,7 +4921,7 @@ static BOOL MaintainLinkedLists(Universe *uni)
 			OOExtraLog(kOOLogEntityVerificationError, @"Broken z_previous %@ list (%d) ***", uni->z_list_start, n);
 			if (result)
 			{
-				OOExtraLog(kOOLogEntityVerificationRebuild, @"REBUILDING z_previous list from z_next list");
+				OOExtraLog(kOOLogEntityVerificationRebuild, @"%@", @"REBUILDING z_previous list from z_next list");
 				checkEnt = uni->z_list_start;
 				NSCAssert(checkEnt != nil, @"Expected z-list to be non-empty.");	// Previously an implicit assumption. -- Ahruman 2011-01-25
 				checkEnt->z_previous = nil;
@@ -4937,7 +4937,7 @@ static BOOL MaintainLinkedLists(Universe *uni)
 	
 	if (!result)
 	{
-		OOExtraLog(kOOLogEntityVerificationRebuild, @"Rebuilding all linked lists from scratch");
+		OOExtraLog(kOOLogEntityVerificationRebuild, @"%@", @"Rebuilding all linked lists from scratch");
 		NSArray *allEntities = uni->entities;
 		uni->x_list_start = nil;
 		uni->y_list_start = nil;
@@ -5166,7 +5166,7 @@ static BOOL MaintainLinkedLists(Universe *uni)
 	Entity* p0 = [entities objectAtIndex:0];
 	if (!(p0->isPlayer))
 	{
-		OOLog(kOOLogInconsistentState, @"***** First entity is not the player in Universe.removeAllEntitiesExceptPlayer - exiting.");
+		OOLog(kOOLogInconsistentState, @"%@", @"***** First entity is not the player in Universe.removeAllEntitiesExceptPlayer - exiting.");
 		exit(EXIT_FAILURE);
 	}
 #endif
@@ -7447,7 +7447,7 @@ static void VerifyDesc(NSString *key, id desc)
 	NSString *key = nil;
 	if (_descriptions == nil)
 	{
-		OOLog(@"descriptions.verify",@"***** FATAL: Tried to verify descriptions, but descriptions was nil - unable to load any descriptions.plist file.");
+		OOLog(@"descriptions.verify", @"%@", @"***** FATAL: Tried to verify descriptions, but descriptions was nil - unable to load any descriptions.plist file.");
 		exit(EXIT_FAILURE);
 	}
 	foreachkey (key, _descriptions)
@@ -7819,7 +7819,7 @@ static void VerifyDesc(NSString *key, id desc)
 
 - (OOSystemID) findSystemAtCoords:(NSPoint) coords withGalaxy:(OOGalaxyID) g
 {
-	OOLog(@"deprecated.function",@"findSystemAtCoords");
+	OOLog(@"deprecated.function", @"%@", @"findSystemAtCoords");
 	return [self findSystemNumberAtCoords:coords withGalaxy:g includingHidden:YES];
 }
 
@@ -9889,19 +9889,19 @@ static OOComparisonResult comparePrice(id dict1, id dict2, void *context)
 {
 	PlayerEntity* player = PLAYER;
 	
-	OO_DEBUG_PUSH_PROGRESS(@"Wormhole and character reset");
+	OO_DEBUG_PUSH_PROGRESS(@"%@", @"Wormhole and character reset");
 	if (activeWormholes) [activeWormholes autorelease];
 	activeWormholes = [[NSMutableArray arrayWithCapacity:16] retain];
 	if (characterPool) [characterPool autorelease];
 	characterPool = [[NSMutableArray arrayWithCapacity:256] retain];
 	OO_DEBUG_POP_PROGRESS();
 	
-	OO_DEBUG_PUSH_PROGRESS(@"Galaxy reset");
+	OO_DEBUG_PUSH_PROGRESS(@"%@", @"Galaxy reset");
 	[self setGalaxyTo: [player galaxyNumber] andReinit:YES];
 	systemID = [player systemID];
 	OO_DEBUG_POP_PROGRESS();
 	
-	OO_DEBUG_PUSH_PROGRESS(@"Player init: setUpShipFromDictionary");
+	OO_DEBUG_PUSH_PROGRESS(@"%@", @"Player init: setUpShipFromDictionary");
 	[player setUpShipFromDictionary:[[OOShipRegistry sharedRegistry] shipInfoForKey:[player shipDataKey]]];	// the standard cobra at this point
 	[player baseMass]; // bootstrap the base mass used in all fuel charge calculations.
 	OO_DEBUG_POP_PROGRESS();


### PR DESCRIPTION
Current master fails to build on GCC 5, which doesn't allow format strings in e.g. `OOLog` to be straightforward strings with no parameters.