### PR TITLE
Shady atmos alternative

### DIFF
--- a/Doc/contributors.txt
+++ b/Doc/contributors.txt
@@ -12,6 +12,7 @@ Nicolas Boulenguez
 CaptSolo
 Eugene Chernyakov (seventh)
 colinh
+Commander_X
 Commander McLane
 Paul Cooper (PhantorGorth)
 Dermot Costello

--- a/Resources/Config/material-defaults.plist
+++ b/Resources/Config/material-defaults.plist
@@ -77,4 +77,23 @@
 		OOSTD_CUBE_MAP = 1;
 		OOSTD_HARSH_MISTRESS = 1;
 	};
+	"atmosphere-material" =
+	{
+	vertex_shader = "oolite-default-atmosphere.vertex";
+	fragment_shader = "oolite-default-atmosphere.fragment";
+		uniforms =
+		{
+			uDiffuseMap = { type = texture; value = 1; };
+			uNormalMap = { type = texture; value = 0; };
+			atmPosition = "relativePosition";
+			atmRadius = "collisionRadius";
+		};
+	};
+	"atmosphere-dynamic-macros" =
+	{
+		IS_OOLITE = 1;
+		OOSTD_DIFFUSE_MAP = 1;
+		OOSTD_CUBE_MAP = 0;
+		OOSTD_HARSH_MISTRESS = 1;
+	};
 }

--- a/Resources/Shaders/oolite-default-atmosphere.fragment
+++ b/Resources/Shaders/oolite-default-atmosphere.fragment
@@ -1,5 +1,5 @@
 /*
-	oolite-default-planet.fragment
+	oolite-default-atmosphere.fragment
 	Default fragment shader for Oolite NEW_PLANETS.
 	
 	
@@ -247,7 +247,8 @@ void main()
 // ignore uDiffuseMap totaly
 //	vec3 diffuseColor = diffuseMapSample.rgb;
 	vec3 diffuseColor = DIFFUSE_LIGHT;
-	totalColor += diffuseColor * diffuseLight;
+	// mix in some light blue color
+	totalColor += diffuseColor * diffuseLight * vec3(0.8, 0.8, 1.0);
 	
 	// Ambient light, biased towards blue.
 	vec3 ambientColor = diffuseColor;

--- a/Resources/Shaders/oolite-default-atmosphere.fragment
+++ b/Resources/Shaders/oolite-default-atmosphere.fragment
@@ -1,0 +1,297 @@
+/*
+	oolite-default-planet.fragment
+	Default fragment shader for Oolite NEW_PLANETS.
+	
+	
+	© 2009–2013 Jens Ayton
+	
+	Permission is hereby granted, free of charge, to any person obtaining a copy
+	of this software and associated documentation files (the "Software"), to deal
+	in the Software without restriction, including without limitation the rights
+	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	copies of the Software, and to permit persons to whom the Software is
+	furnished to do so, subject to the following conditions:
+	
+	The above copyright notice and this permission notice shall be included in all
+	copies or substantial portions of the Software.
+	
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+	SOFTWARE.
+*/
+
+#define IS_OOLITE  1
+#define OOSTD_DIFFUSE_MAP 1
+#define OOSTD_SPECULAR_MAP 0
+#define OOSTD_NORMAL_AND_SPECULAR_MAP 0
+#define OOSTD_HARSH_MISTRESS 1
+
+#ifndef IS_OOLITE
+#define IS_OOLITE 0
+#endif
+
+#if IS_OOLITE
+#define SPECULAR_LIGHT		(gl_LightSource[1].specular.rgb)
+#define DIFFUSE_LIGHT		(gl_LightSource[1].diffuse.rgb)
+#define AMBIENT_LIGHT		(gl_LightModel.ambient.rgb)
+#else
+#define SPECULAR_LIGHT 						vec3(0.8)
+#define DIFFUSE_LIGHT 						vec3(0.8)
+#define AMBIENT_LIGHT						vec3(0.2)
+#define OOSTD_ILLUMINATION_MAP				1
+#define OOSTD_NORMAL_MAP					1
+#define OOSTD_SPECULAR_MAP					1
+#endif
+
+
+#ifndef OOSTD_ILLUMINATION_MAP
+#define OOSTD_ILLUMINATION_MAP 0
+#endif
+#ifndef OOSTD_DIFFUSE_AND_ILLUMINATION_MAP
+#define OOSTD_DIFFUSE_AND_ILLUMINATION_MAP 0
+#endif
+#ifndef OOSTD_NORMAL_MAP
+#define OOSTD_NORMAL_MAP 0
+#endif
+#ifndef OOSTD_SPECULAR_MAP
+#define OOSTD_SPECULAR_MAP 0
+#endif
+#ifndef OOSTD_NORMAL_AND_SPECULAR_MAP
+#define OOSTD_NORMAL_AND_SPECULAR_MAP 0
+#endif
+#ifndef OOSTD_HARSH_MISTRESS
+#define OOSTD_HARSH_MISTRESS 0
+#endif
+
+
+// Illumination map parameters.
+#define USE_ILLUMINATION OOSTD_ILLUMINATION_MAP || OOSTD_DIFFUSE_AND_ILLUMINATION_MAP
+#if OOSTD_ILLUMINATION_MAP
+uniform sampler2D		uIlluminationMap;
+#define ILLUMINATION_COLOR texture2D(uIlluminationMap, texCoords).rgb
+#elif OOSTD_DIFFUSE_AND_ILLUMINATION_MAP
+#define ILLUMINATION_COLOR (diffuseMapSample.a * vec3(0.8, 0.8, 0.4))
+#endif
+
+
+// Specular map parameters.
+// Separate OOSTD_SPECULAR_MAP is for testing in OpenGL Shader Builder, which doesn’t deal with alpha channels sensibly.
+#define USE_SPECULAR OOSTD_SPECULAR_MAP || OOSTD_NORMAL_AND_SPECULAR_MAP
+#if (OOSTD_SPECULAR_MAP)
+uniform sampler2D		uSpecularMap;
+#define SPECULAR_FACTOR (texture2D(uSpecularMap, texCoords).r)
+#elif OOSTD_NORMAL_AND_SPECULAR_MAP
+#define SPECULAR_FACTOR (normalMapSample.a)
+#endif
+
+
+// Normal map parameters.
+#define USE_NORMAL_MAP OOSTD_NORMAL_MAP || OOSTD_NORMAL_AND_SPECULAR_MAP
+
+/*	"Harsh shadow factor": degree to which normal map affects global diffuse light
+	with terminator and full shadow, as opposed to "local light" which is a normal
+	Lambertian light.
+	
+	Terminator threshold: defines the width and colour of the terminator. The
+	numbers are cosines of the angle where it transitions to full light.
+	
+	Both of these factors are ignored in simple shader mode.
+*/
+#if OOSTD_HARSH_MISTRESS
+const float 			kHarshShadowFactor	= 0.3;
+const vec3				kTerminatorThreshold = vec3(0.08);
+#else
+const float 			kHarshShadowFactor	= 0.05;
+const vec3				kTerminatorThreshold = vec3(0.1, 0.105, 0.12);
+#endif
+
+
+// Texture coordinate calcuation.
+#define TEXTURE_COORDS vec2(TexLongitude(coords.x, coords.z), vTexCoords.t)
+
+
+#if OOSTD_CUBE_MAP
+uniform samplerCube		uDiffuseMap;
+#if USE_NORMAL_MAP
+uniform samplerCube		uNormalMap;
+#endif
+#else
+uniform sampler2D		uDiffuseMap;
+#if USE_NORMAL_MAP
+uniform sampler2D		uNormalMap;
+#endif
+#endif
+
+uniform vec4			atmPosition;
+uniform float			atmRadius;
+
+// No vNormal, because normal is always 0,0,1 in tangent space.
+varying vec3			vEyeVector;
+varying vec2			vTexCoords;
+varying vec3			vLight1Vector;
+varying vec3			vCoords;
+
+
+vec3 CalcDiffuseIntensity(in vec3 lightVector, in vec3 normal)
+{
+	float LdotN = lightVector.z;
+	
+#if USE_NORMAL_MAP
+	float globalTerm = dot(normalize(mix(vec3(0.0, 0.0, 1.0), normal, kHarshShadowFactor)), lightVector);
+#else
+	float globalTerm = LdotN;
+#endif
+	
+	// Hard terminator with slight redish-orange tinge. Note: threshold values are cosines.
+	vec3 baseLight = smoothstep(vec3(0.0), kTerminatorThreshold, vec3(globalTerm));
+	
+#if USE_NORMAL_MAP
+	// Modulate with normal-mapped "local" illumination.
+	float local = dot(lightVector, normal);
+	local -= LdotN;
+	
+	baseLight *= local + 1.0;
+#endif
+	
+	return baseLight;
+}
+
+
+vec3 CalcSpecularLight(in vec3 lightVector, in vec3 eyeVector, in float exponent, in vec3 normal, in vec3 lightColor)
+{
+#if USE_NORMAL_MAP
+	vec3 reflection = -reflect(lightVector, normal);
+	float NdotE = dot(normal, eyeVector);
+#else
+	/*	reflect(I, N) is defined as I - 2 * dot(N, I) * N
+		If N is (0,0,1), this becomes (I.x,I.y,-I.z).
+		Note that we want it negated as per above.
+	*/
+	vec3 reflection = vec3(-lightVector.x, -lightVector.y, lightVector.z);
+	float NdotE = eyeVector.z;
+#endif
+	
+	float RdotE = max(dot(reflection, eyeVector), 0.0);
+	float intensity = pow(max(RdotE, 0.0), exponent);
+	
+	// Approximate Fresnel term.
+	float kRefract = 1.0/1.33;	// Index of refraction of water.
+	float F0 = ((kRefract - 1.0) * (kRefract - 1.0)) / ((kRefract + 1.0) * (kRefract + 1.0));
+	float Fa = F0 + pow((1.0 - NdotE), 4.0) * (1.0 - F0);
+	intensity *= 0.4 + Fa;
+	
+	return lightColor * intensity;
+}
+
+
+/*	Approximation of atan(y/z) with quadrant rectification, scaled to -0.5..0.5 instead of -pi..pi.
+	It is assumed that the values are in range. You are not expected to understand this.
+*/
+float TexLongitude(float z, float y)
+{
+	const float	k2Pi = 6.283185307179586;
+	const float	kMagic = 0.2732395447351;	// (4 - pi) / pi
+	
+	float ratio = z / y;
+	
+	float r1 = 1.0 / ((ratio + kMagic / ratio) * k2Pi);	// Result when abs(z) >= abs(x).
+	float r2 = 0.25 * sign(ratio) - ratio / ((1.0 + kMagic * ratio * ratio) * k2Pi);  // Result when abs(z) <= abs(x).
+	
+	float result = (abs(ratio) > 1.0) ? r1 : r2;
+	
+	// Adjust for sector.
+	// Equivalent to (z < 0.0) ? ((y > 0.0) ? 0.75 : -0.25) : 0.25.
+	// Well, technically not equivalent for z < 0, y = 0, but you'll very rarely see that exact case.
+	return result + step(z, 0.0) * sign(y) * 0.5 + 0.25;
+}
+
+
+void main()
+{
+	vec3 totalColor = vec3(0);
+	vec3 coords = normalize(vCoords);
+	vec2 texCoords = TEXTURE_COORDS;
+	
+	/*	Fun sphere facts: the normalized coordinates of a point on a sphere at the origin
+		is equal to the object-space normal of the surface at that point.
+		Furthermore, we can construct the binormal (a vector pointing westward along the
+		surface) as the cross product of the normal with the Y axis. (This produces
+		singularities at the pole, but there have to be singularities according to the
+		Hairy Ball Theorem.) The tangent (a vector north along the surface) is then the
+		inverse of the cross product of the normal and binormal.
+	*/
+#if USE_NORMAL_MAP
+#if OOSTD_CUBE_MAP
+	vec4 normalMapSample = textureCube(uNormalMap, vCoords);
+#else
+	vec4 normalMapSample = texture2D(uNormalMap, texCoords);
+#endif
+	vec3 normal = normalize(normalMapSample.xyz - vec3(0.5));
+#else
+	vec3 normal = vec3(0, 0, 1);
+#endif
+	
+	// Diffuse light
+	vec3 light1Vector = normalize(vLight1Vector);
+	vec3 diffuseIntensity = CalcDiffuseIntensity(light1Vector, normal);
+	vec3 diffuseLight = diffuseIntensity * DIFFUSE_LIGHT;
+#if OOSTD_CUBE_MAP
+	vec4 diffuseMapSample = textureCube(uDiffuseMap, vCoords);
+#else
+	vec4 diffuseMapSample = texture2D(uDiffuseMap, texCoords);
+#endif
+// ignore uDiffuseMap totaly
+//	vec3 diffuseColor = diffuseMapSample.rgb;
+	vec3 diffuseColor = DIFFUSE_LIGHT;
+	totalColor += diffuseColor * diffuseLight;
+	
+	// Ambient light, biased towards blue.
+	vec3 ambientColor = diffuseColor;
+#if !OOSTD_HARSH_MISTRESS
+	ambientColor *= vec3(0.8, 0.8, 1.0);
+#endif
+	totalColor += AMBIENT_LIGHT * ambientColor;
+	
+	// Specular light.
+#if USE_SPECULAR
+	float specularFactor = SPECULAR_FACTOR;
+	vec3 specularLight = CalcSpecularLight(light1Vector, normalize(vEyeVector), 30.0 * specularFactor, normal, SPECULAR_LIGHT);
+	totalColor += specularLight * 0.6 * specularFactor;
+#endif
+	
+#if USE_ILLUMINATION
+	vec3 illuminationColor = ILLUMINATION_COLOR;
+	totalColor += (1.0 - diffuseIntensity.r) * illuminationColor;
+#endif
+
+	float atmDistance = sqrt(pow(atmPosition.x,2) + pow(atmPosition.y,2) + pow(atmPosition.z,2) );
+	float minDistance = atmRadius + 3500.0;
+	float newOpacity = 0.0;
+	if ( ( atmDistance < 600000.0 ) && ( atmDistance > minDistance ) )
+	{
+		float quant = 1.0;
+		quant = ( atmDistance > 560000.0 ? ( 40000.0 - (atmDistance - 560000.0 ) ) / 40000.0 : ( atmDistance < (minDistance + 2000.0 ) ? ( atmDistance - minDistance ) / 2000.0 : quant) );
+		
+		vec3 nvEyeVector = normalize(vEyeVector);
+
+		
+		float dp = abs(dot(nvEyeVector, vec3(0.0,0.0,1.0)));
+		if (dp > 0.16) {
+			newOpacity = min(1.0, pow(0.16/dp,2.0)) * quant;
+		}
+		else
+		{
+			newOpacity = pow(dp/0.16,5.0) * quant;
+		}
+	}
+//	float termBorder = dot(vec3(0,0,1), light1Vector);
+  
+//  newOpacity = (dot(vec3(0,0,1), light1Vector) > kHarshShadowFactor ? newOpacity:smoothstep(0.0,0.15,0.05));
+
+//	gl_FragColor = vec4((termBorder > 0?totalColor:diffuseLight) * pow((kHarshShadowFactor + termBorder),0.33), newOpacity);
+	gl_FragColor = vec4(totalColor, newOpacity);
+}

--- a/Resources/Shaders/oolite-default-atmosphere.fragment
+++ b/Resources/Shaders/oolite-default-atmosphere.fragment
@@ -24,11 +24,6 @@
 	SOFTWARE.
 */
 
-#define IS_OOLITE  1
-#define OOSTD_DIFFUSE_MAP 1
-#define OOSTD_SPECULAR_MAP 0
-#define OOSTD_NORMAL_AND_SPECULAR_MAP 0
-#define OOSTD_HARSH_MISTRESS 1
 
 #ifndef IS_OOLITE
 #define IS_OOLITE 0
@@ -271,11 +266,14 @@ void main()
 
 	float atmDistance = sqrt(pow(atmPosition.x,2) + pow(atmPosition.y,2) + pow(atmPosition.z,2) );
 	float minDistance = atmRadius + 3500.0;
+	float fadeDist = atmRadius * 12.0;
+	float fadeRate = 140000.0;
+	float fadeStart = fadeDist - fadeRate;
 	float newOpacity = 0.0;
-	if ( ( atmDistance < 600000.0 ) && ( atmDistance > minDistance ) )
+	if ( ( atmDistance < fadeDist ) && ( atmDistance > minDistance ) )
 	{
 		float quant = 1.0;
-		quant = ( atmDistance > 560000.0 ? ( 40000.0 - (atmDistance - 560000.0 ) ) / 40000.0 : ( atmDistance < (minDistance + 2000.0 ) ? ( atmDistance - minDistance ) / 2000.0 : quant) );
+		quant = ( atmDistance > fadeStart ? ( fadeRate - (atmDistance - fadeStart) ) / fadeRate : ( atmDistance < (minDistance + 2000.0 ) ? ( atmDistance - minDistance ) / 2000.0 : quant) );
 		
 		vec3 nvEyeVector = normalize(vEyeVector);
 
@@ -289,10 +287,6 @@ void main()
 			newOpacity = pow(dp/0.16,5.0) * quant;
 		}
 	}
-//	float termBorder = dot(vec3(0,0,1), light1Vector);
-  
-//  newOpacity = (dot(vec3(0,0,1), light1Vector) > kHarshShadowFactor ? newOpacity:smoothstep(0.0,0.15,0.05));
 
-//	gl_FragColor = vec4((termBorder > 0?totalColor:diffuseLight) * pow((kHarshShadowFactor + termBorder),0.33), newOpacity);
 	gl_FragColor = vec4(totalColor, newOpacity);
 }

--- a/Resources/Shaders/oolite-default-atmosphere.vertex
+++ b/Resources/Shaders/oolite-default-atmosphere.vertex
@@ -1,5 +1,5 @@
 /*
-	oolite-default-planet.vertex
+	oolite-default-atmosphere.vertex
 	Default vertex shader for Oolite's NEW_PLANETS
 	
 	

--- a/Resources/Shaders/oolite-default-atmosphere.vertex
+++ b/Resources/Shaders/oolite-default-atmosphere.vertex
@@ -1,0 +1,54 @@
+/*
+	oolite-default-planet.vertex
+	Default vertex shader for Oolite's NEW_PLANETS
+	
+	
+	© 2009–2013 Jens Ayton
+	
+	This program is free software; you can redistribute it and/or
+	modify it under the terms of the GNU General Public License
+	as published by the Free Software Foundation; either version 2
+	of the License, or (at your option) any later version.
+	
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+	
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+	MA 02110-1301, USA.
+*/
+
+// No vNormal, because normal is always 0,0,1 in tangent space.
+uniform mat3			ooliteNormalMatrix;
+uniform mat4			ooliteModelView;
+uniform mat4			ooliteModelViewProjection;
+varying vec3			vEyeVector;
+varying vec2			vTexCoords;
+varying vec3			vLight1Vector;
+varying vec3			vCoords;
+
+
+void main(void)
+{
+	vCoords = gl_Vertex.xyz;
+	
+	// Build tangent basis.
+	vec3 normal = normalize(ooliteNormalMatrix * gl_Normal);
+	vec3 binormal = normalize(cross(normal, ooliteNormalMatrix * vec3(0, 1, 0)));
+	vec3 tangent = -cross(normal, binormal);
+	
+	mat3 TBN = mat3(tangent, binormal, normal);
+	
+	vec3 eyeVector = -vec3(ooliteModelView * gl_Vertex);
+	vEyeVector = eyeVector * TBN;
+
+	vec3 light1Vector = gl_LightSource[1].position.xyz + eyeVector;
+	vLight1Vector = light1Vector * TBN;
+	
+	vTexCoords = gl_MultiTexCoord0.st;
+	gl_Position = ooliteModelViewProjection * gl_Vertex;
+}
+

--- a/src/Core/Entities/OOPlanetEntity.m
+++ b/src/Core/Entities/OOPlanetEntity.m
@@ -830,6 +830,35 @@ static OOColor *ColorWithHSBColor(Vector c)
 	/* Generate atmosphere texture */
 	if (!isMoon)
 	{
+#if OO_SHADERS
+		NSMutableDictionary *aConfig = [[[materialDefaults oo_dictionaryForKey:@"atmosphere-material"] mutableCopy] autorelease];
+		[aConfig setObject:[NSArray arrayWithObjects:diffuseMap, normalMap, nil] forKey:@"_oo_texture_objects"];
+		
+		NSDictionary *amacros = [materialDefaults oo_dictionaryForKey:@"atmosphere-dynamic-macros"];
+		
+		OOMaterial *dynamicMaterial = [OOShaderMaterial shaderMaterialWithName:@"dynamic"
+																configuration:aConfig
+																macros:amacros
+																bindingTarget:self];
+																
+		if (dynamicMaterial == nil)
+		{
+			/* Backup plan */
+			OOLog(@"texture.planet.generate",@"Preparing atmosphere for planet %@",self);
+			/* Generate a standalone atmosphere texture */
+			OOTexture *atmosphere = nil;
+			[OOStandaloneAtmosphereGenerator generateAtmosphereTexture:&atmosphere
+									withInfo:_materialParameters];
+		
+			OOLog(@"texture.planet.generate",@"Planet %@ has atmosphere %@",self,atmosphere);
+			OOSingleTextureMaterial *dynamicMaterial = [[OOSingleTextureMaterial alloc] initWithName:@"dynamic"
+														texture:atmosphere configuration:nil];
+			[dynamicMaterial autorelease];
+		}
+		
+		[_atmosphereDrawable setMaterial:dynamicMaterial];
+
+#else
 		OOLog(@"texture.planet.generate",@"Preparing atmosphere for planet %@",self);
 		/* Generate a standalone atmosphere texture */
 		OOTexture *atmosphere = nil;
@@ -841,6 +870,7 @@ static OOColor *ColorWithHSBColor(Vector c)
 		OOSingleTextureMaterial *dynamicMaterial = [[OOSingleTextureMaterial alloc] initWithName:@"dynamic" texture:atmosphere configuration:nil];
 		[_atmosphereDrawable setMaterial:dynamicMaterial];
 		[dynamicMaterial release];
+#endif
 	}
 
 	OOMaterial *material = nil;

--- a/src/Core/Entities/OOPlanetEntity.m
+++ b/src/Core/Entities/OOPlanetEntity.m
@@ -851,7 +851,7 @@ static OOColor *ColorWithHSBColor(Vector c)
 									withInfo:_materialParameters];
 		
 			OOLog(@"texture.planet.generate",@"Planet %@ has atmosphere %@",self,atmosphere);
-			OOSingleTextureMaterial *dynamicMaterial = [[OOSingleTextureMaterial alloc] initWithName:@"dynamic"
+			dynamicMaterial = [[OOSingleTextureMaterial alloc] initWithName:@"dynamic"
 														texture:atmosphere configuration:nil];
 			[dynamicMaterial autorelease];
 		}


### PR DESCRIPTION
As already mentioned in the internal devs mailing list, this is a request to merge Commander_X's new atmosphere shader to master.

The effect looks good and, on my system, offers about 10 FPS more than the atmosphere implementation we have now. The effect fades out when the atmosphere is entered or we move too far away from the planet. The effect's fade in/out distance as well as the fade in/out rate are planet radius dependent. The old effect is still applied on detail levels below Extra Detail.

The shader can still use some optimizations but I think that it is now at a state where it can be imported to trunk and tested by a wider user base. 