### PR TITLE
Support for shader + texture atmosphere drawables simultaneously

### DIFF
--- a/src/Core/Entities/OOPlanetEntity.h
+++ b/src/Core/Entities/OOPlanetEntity.h
@@ -41,6 +41,7 @@ MA 02110-1301, USA.
 @private
 	OOPlanetDrawable		*_planetDrawable;
 	OOPlanetDrawable		*_atmosphereDrawable;
+	OOPlanetDrawable		*_atmosphereShaderDrawable;
 	
 	BOOL					_miniature;
 	OOColor					*_airColor;
@@ -84,6 +85,7 @@ MA 02110-1301, USA.
 
 - (OOMaterial *) material;
 - (OOMaterial *) atmosphereMaterial;
+- (OOMaterial *) atmosphereShaderMaterial;
 
 - (BOOL) isFinishedLoading;
 

--- a/src/Core/Entities/OOPlanetEntity.m
+++ b/src/Core/Entities/OOPlanetEntity.m
@@ -147,6 +147,9 @@ static const double kMesosphere = 10.0 * ATMOSPHERE_DEPTH;	// atmosphere effect 
 #if NEW_ATMOSPHERE
 	if (atmosphere)
 	{
+		// shader atmosphere always has a radius of collision_radius + ATMOSPHERE_DEPTH. For texture atmosphere, we need to check
+		// if a shader atmosphere is also used. If yes, set its radius to just cover the planet so that it doesn't conflict with 
+		// the shader atmosphere at the planet edges. If no shader atmosphere is used, then set it to the standard radius
 		double atmosphereRadius = [UNIVERSE detailLevel] >= DETAIL_LEVEL_EXTRAS ? collision_radius : collision_radius + ATMOSPHERE_DEPTH;
 		_atmosphereDrawable = [[OOPlanetDrawable atmosphereWithRadius:atmosphereRadius] retain];
 		_atmosphereShaderDrawable = [[OOPlanetDrawable atmosphereWithRadius:collision_radius + ATMOSPHERE_DEPTH] retain];
@@ -559,6 +562,7 @@ static OOColor *ColorWithHSBColor(Vector c)
 			}
 			if (canDrawShaderAtmosphere && [_atmosphereDrawable radius] != collision_radius)
 			{
+				// if shader atmo is in use, force texture atmo radius to just collision_radius for cosmetic purposes
 				[_atmosphereDrawable setRadius:collision_radius];
 			}
 			[UNIVERSE setAirResistanceFactor:0.0f];	// out of atmosphere - no air friction


### PR DESCRIPTION
With the recent implementation of shader atmospheres, it became evident that the cloud effect (an internally generated texture) had to go, as the implementation was giving us only two options: either shader or texture atmosphere. The design also predicted that, if the shader atmosphere could not be generated for whatever reason, then there was an automatic fall-back to the texture  generated one.

This PR enables both atmosphere types to co-exist and I believe the visual result is worth it. The implementation is relatively simple and relies on two atmosphere drawables being defined per planet. One is for a texture and the other is for a shader effect. The design tries to keep as close as possible to the earlier one. Now, a texture atmosphere is always generated, like in 1.84. The shader generated drawable is also attempted and, if for whatever reason this cannot happen (e.g. uncompilable shader or gfx set to less than Extra Detail), then the texture atmosphere alone is used.

The PR contains some code that decides the radius of each of the drawables that may require further clarification. The idea is for the two drawables to co-exist, but if they both have the same dimensions there is visible interference between the two at the planet's edges. So, what we do is this: If both drawables are successfully created, then the shader one is set to the (standard) collision_radius + ATMOSPHERE_DEPTH, being the outmost, "primary" one and the texture drawable is set to just cover the planet. If the shader drawable is not created, then the texture one is set to the standard atmosphere radius, so that it looks the same as in 1.84. I believe this is OK for cosmetic reasons and did not indicate any gameplay problems during testing at various distances from the planet.

And this is what it looks like, with an ambient level setting of 0.15:
![disoimprovedatmo01](https://cloud.githubusercontent.com/assets/623526/23992350/d0e3a058-0a3c-11e7-8459-9235287d2617.jpg)
![laveimprovedatmo02](https://cloud.githubusercontent.com/assets/623526/23992364/dbb36748-0a3c-11e7-8192-14db174f7a61.jpg)
![raleorimprovedatmo01](https://cloud.githubusercontent.com/assets/623526/23992392/f7745708-0a3c-11e7-900a-137b0fea4aed.jpg)

