### PR TITLE
Perlin3D Planet and Atmosphere Textures as planetinfo.plist Option

### DIFF
--- a/src/Core/Entities/OOPlanetEntity.m
+++ b/src/Core/Entities/OOPlanetEntity.m
@@ -162,7 +162,7 @@ static const double kMesosphere = 10.0 * ATMOSPHERE_DEPTH;	// atmosphere effect 
 		_airColor = [planetInfo objectForKey:@"air_color"];
 		// OOLog (@"planet.debug",@" translated air colour:%@ cloud colour:%@ polar cloud color:%@", [_airColor rgbaDescription],[(OOColor *)[planetInfo objectForKey:@"cloud_color"] rgbaDescription],[(OOColor *)[planetInfo objectForKey:@"polar_cloud_color"] rgbaDescription]);
 
-		_materialParameters = [planetInfo dictionaryWithValuesForKeys:[NSArray arrayWithObjects:@"cloud_fraction", @"air_color",  @"cloud_color", @"polar_cloud_color", @"cloud_alpha", @"land_fraction", @"land_color", @"sea_color", @"polar_land_color", @"polar_sea_color", @"noise_map_seed", @"economy", @"polar_fraction", @"isMiniature", nil]];
+		_materialParameters = [planetInfo dictionaryWithValuesForKeys:[NSArray arrayWithObjects:@"cloud_fraction", @"air_color",  @"cloud_color", @"polar_cloud_color", @"cloud_alpha", @"land_fraction", @"land_color", @"sea_color", @"polar_land_color", @"polar_sea_color", @"noise_map_seed", @"economy", @"polar_fraction", @"isMiniature", @"perlin_3d", nil]];
 	}
 	else
 #else
@@ -175,7 +175,7 @@ static const double kMesosphere = 10.0 * ATMOSPHERE_DEPTH;	// atmosphere effect 
 	if (YES) // create _materialParameters when NEW_ATMOSPHERE is set to 0
 #endif
 	{
-		_materialParameters = [planetInfo dictionaryWithValuesForKeys:[NSArray arrayWithObjects:@"land_fraction", @"land_color", @"sea_color", @"polar_land_color", @"polar_sea_color", @"noise_map_seed", @"economy", @"polar_fraction",  @"isMiniature",  nil]];
+		_materialParameters = [planetInfo dictionaryWithValuesForKeys:[NSArray arrayWithObjects:@"land_fraction", @"land_color", @"sea_color", @"polar_land_color", @"polar_sea_color", @"noise_map_seed", @"economy", @"polar_fraction",  @"isMiniature", @"perlin_3d", nil]];
 	}
 	[_materialParameters retain];
 	
@@ -213,7 +213,7 @@ static const double kMesosphere = 10.0 * ATMOSPHERE_DEPTH;	// atmosphere effect 
 	int		deltaT = floor(fmod([PLAYER clockTimeAdjusted], 86400));
 	quaternion_rotate_about_axis(&orientation, _rotationAxis, _rotationalVelocity * deltaT);
 	quaternion_rotate_about_axis(&_atmosphereOrientation, kBasisYVector, _atmosphereRotationalVelocity * deltaT);
-
+	
 	
 #ifdef OO_DUMP_PLANETINFO
 #define CPROP(PROP)	OOLog(@"planetinfo.record",@#PROP " = %@;",[(OOColor *)[planetInfo objectForKey:@#PROP] descriptionComponents]);

--- a/src/Core/Materials/OOPlanetTextureGenerator.h
+++ b/src/Core/Materials/OOPlanetTextureGenerator.h
@@ -28,7 +28,6 @@ MA 02110-1301, USA.
 #import "OOTextureGenerator.h"
 #import "OOMaths.h"
 
-#define PERLIN_3D			0
 
 @class OOPlanetNormalMapGenerator, OOPlanetAtmosphereGenerator;
 
@@ -67,9 +66,11 @@ typedef struct OOPlanetTextureGeneratorInfo
 	float							*fbmBuffer;
 	float							*qBuffer;
 	
-#if PERLIN_3D
 	uint16_t						*permutations;
-#endif
+	
+	unsigned						planetAspectRatio;
+	unsigned						planetScaleOffset;
+	BOOL							perlin3d;
 } OOPlanetTextureGeneratorInfo;
 
 

--- a/src/Core/Materials/OOStandaloneAtmosphereGenerator.h
+++ b/src/Core/Materials/OOStandaloneAtmosphereGenerator.h
@@ -29,7 +29,6 @@ MA 02110-1301, USA.
 #import "OOTextureGenerator.h"
 #import "OOMaths.h"
 
-#define PERLIN_3D			0
 
 typedef struct OOStandaloneAtmosphereGeneratorInfo
 {
@@ -48,9 +47,11 @@ typedef struct OOStandaloneAtmosphereGeneratorInfo
 	// Noise generation stuff.
 	float							*fbmBuffer;
 	
-#if PERLIN_3D
 	uint16_t						*permutations;
-#endif
+	
+	unsigned						planetAspectRatio;
+	unsigned						planetScaleOffset;
+	BOOL							perlin3d;
 } OOStandaloneAtmosphereGeneratorInfo;
 
 


### PR DESCRIPTION
Rather than setting Perlin3D planet and atmosphere textures perference at compile time, I thought that it could be a better idea if we could have this selection as an option. This could motivate also contributors to try to optimize the Perlin3D code, too.

This pull request implements this idea. The type of texture for planets and atmospheres can be set via the "perlin_3d" key in planetinfo.plist for each planet separately or for everything, if set inside the "universal" block. 

By default we keep Perlin3D disabled due to its performance impact. There is an approximately two seconds delay on my system when viewing planets in the F7 screen with this enabled. Hyperspace transit takes somewhat longer too, as the new system textures get created. However, more powerful systems could maybe use this without getting too penalized, so it would be interesting to check the feature on more recent machines. 