### PR TITLE
Adding 'addCargoEntity' method to player ship

### DIFF
--- a/src/Core/Entities/ShipEntity.h
+++ b/src/Core/Entities/ShipEntity.h
@@ -1143,6 +1143,7 @@ Vector positionOffsetForShipInRotationToAlignment(ShipEntity* ship, Quaternion q
 - (void) getTractoredBy:(ShipEntity *)other;
 - (void) scoopIn:(ShipEntity *)other;
 - (void) scoopUp:(ShipEntity *)other;
+- (void) scoopUpProcess:(ShipEntity *)other processEvents:(BOOL) proc_events processMessages:(BOOL) proc_messages;
 
 - (BOOL) abandonShip;
 

--- a/src/Core/Entities/ShipEntity.m
+++ b/src/Core/Entities/ShipEntity.m
@@ -12890,6 +12890,12 @@ Vector positionOffsetForShipInRotationToAlignment(ShipEntity* ship, Quaternion q
 
 - (void) scoopUp:(ShipEntity *)other
 {
+	[self scoopUpProcess:other processEvents:YES processMessages:YES];
+}
+
+
+- (void) scoopUpProcess:(ShipEntity *)other processEvents:(BOOL) proc_events processMessages:(BOOL) proc_messages
+{
 	if (other == nil)  return;
 	
 	OOCommodityType	co_type = nil;
@@ -12914,7 +12920,10 @@ Vector positionOffsetForShipInRotationToAlignment(ShipEntity* ship, Quaternion q
 				//scripting
 				PlayerEntity *player = PLAYER;
 				[player setScriptTarget:self];
-				[other doScriptEvent:OOJSID("shipWasScooped") withArgument:self];
+				if (proc_events)
+				{
+					[other doScriptEvent:OOJSID("shipWasScooped") withArgument:self];
+				}
 				
 				if ([other commodityType] != nil)
 				{
@@ -12924,7 +12933,7 @@ Vector positionOffsetForShipInRotationToAlignment(ShipEntity* ship, Quaternion q
 				}
 				else
 				{
-					if (isPlayer && [other showScoopMessage])
+					if (isPlayer && [other showScoopMessage] && proc_messages)
 					{
 						[UNIVERSE clearPreviousMessage];
 						NSString *shipName = [other displayName];
@@ -12964,9 +12973,9 @@ Vector positionOffsetForShipInRotationToAlignment(ShipEntity* ship, Quaternion q
 		
 		if (isPlayer)
 		{
-			if ([other crew])
+			if ([other crew])			
 			{
-				if ([other showScoopMessage])
+				if ([other showScoopMessage] && proc_messages)
 				{
 					[UNIVERSE clearPreviousMessage];
 					unsigned i;
@@ -12988,11 +12997,14 @@ Vector positionOffsetForShipInRotationToAlignment(ShipEntity* ship, Quaternion q
 						}
 					}
 				}
-				[(PlayerEntity *)self playEscapePodScooped];
+				if (proc_events) 
+				{
+					[(PlayerEntity *)self playEscapePodScooped];
+				}
 			}
 			else
 			{
-				if ([other showScoopMessage])
+				if ([other showScoopMessage] && proc_messages)
 				{
 					[UNIVERSE clearPreviousMessage];
 					[UNIVERSE addMessage:[UNIVERSE describeCommodity:co_type amount:co_amount] forCount:4.5];
@@ -13005,7 +13017,10 @@ Vector positionOffsetForShipInRotationToAlignment(ShipEntity* ship, Quaternion q
 		[shipAI message:@"CARGO_SCOOPED"];
 		if (max_cargo && [cargo count] >= [self maxAvailableCargoSpace])  [shipAI message:@"HOLD_FULL"];
 	}
-	[self doScriptEvent:OOJSID("shipScoopedOther") withArgument:other]; // always fire, even without commodity.
+	if (proc_events)
+	{
+		[self doScriptEvent:OOJSID("shipScoopedOther") withArgument:other]; // always fire, even without commodity.
+	}
 
 	// if shipScoopedOther does something strange to the object, we must
 	// then remove it from the hold, or it will be over-retained

--- a/src/Core/Entities/ShipEntity.m
+++ b/src/Core/Entities/ShipEntity.m
@@ -12894,7 +12894,7 @@ Vector positionOffsetForShipInRotationToAlignment(ShipEntity* ship, Quaternion q
 }
 
 
-- (void) scoopUpProcess:(ShipEntity *)other processEvents:(BOOL) proc_events processMessages:(BOOL) proc_messages
+- (void) scoopUpProcess:(ShipEntity *)other processEvents:(BOOL) procEvents processMessages:(BOOL) procMessages
 {
 	if (other == nil)  return;
 	
@@ -12920,7 +12920,7 @@ Vector positionOffsetForShipInRotationToAlignment(ShipEntity* ship, Quaternion q
 				//scripting
 				PlayerEntity *player = PLAYER;
 				[player setScriptTarget:self];
-				if (proc_events)
+				if (procEvents)
 				{
 					[other doScriptEvent:OOJSID("shipWasScooped") withArgument:self];
 				}
@@ -12933,7 +12933,7 @@ Vector positionOffsetForShipInRotationToAlignment(ShipEntity* ship, Quaternion q
 				}
 				else
 				{
-					if (isPlayer && [other showScoopMessage] && proc_messages)
+					if (isPlayer && [other showScoopMessage] && procMessages)
 					{
 						[UNIVERSE clearPreviousMessage];
 						NSString *shipName = [other displayName];
@@ -12975,7 +12975,7 @@ Vector positionOffsetForShipInRotationToAlignment(ShipEntity* ship, Quaternion q
 		{
 			if ([other crew])			
 			{
-				if ([other showScoopMessage] && proc_messages)
+				if ([other showScoopMessage] && procMessages)
 				{
 					[UNIVERSE clearPreviousMessage];
 					unsigned i;
@@ -12997,14 +12997,14 @@ Vector positionOffsetForShipInRotationToAlignment(ShipEntity* ship, Quaternion q
 						}
 					}
 				}
-				if (proc_events) 
+				if (procEvents) 
 				{
 					[(PlayerEntity *)self playEscapePodScooped];
 				}
 			}
 			else
 			{
-				if ([other showScoopMessage] && proc_messages)
+				if ([other showScoopMessage] && procMessages)
 				{
 					[UNIVERSE clearPreviousMessage];
 					[UNIVERSE addMessage:[UNIVERSE describeCommodity:co_type amount:co_amount] forCount:4.5];
@@ -13017,7 +13017,7 @@ Vector positionOffsetForShipInRotationToAlignment(ShipEntity* ship, Quaternion q
 		[shipAI message:@"CARGO_SCOOPED"];
 		if (max_cargo && [cargo count] >= [self maxAvailableCargoSpace])  [shipAI message:@"HOLD_FULL"];
 	}
-	if (proc_events)
+	if (procEvents)
 	{
 		[self doScriptEvent:OOJSID("shipScoopedOther") withArgument:other]; // always fire, even without commodity.
 	}

--- a/src/Core/Scripting/OOJSShip.m
+++ b/src/Core/Scripting/OOJSShip.m
@@ -2202,8 +2202,8 @@ static JSBool ShipAddCargoEntity(JSContext *context, uintN argc, jsval *vp)
 	OOJS_NATIVE_ENTER(context)
 	ShipEntity				*thisEnt = nil;
 	ShipEntity              *target = nil;
-	JSBool					proc_events = NO;
-	JSBool					proc_messages = NO;
+	JSBool					procEvents = NO;
+	JSBool					procMessages = NO;
 
 	GET_THIS_SHIP(thisEnt);
 
@@ -2213,6 +2213,7 @@ static JSBool ShipAddCargoEntity(JSContext *context, uintN argc, jsval *vp)
 		return NO;
 	}
 	if (EXPECT_NOT(argc == 0 ||
+				   JSVAL_IS_NULL(OOJS_ARGV[0]) ||
 				   !JSVAL_IS_OBJECT(OOJS_ARGV[0]) ||
 				   !JSShipGetShipEntity(context, JSVAL_TO_OBJECT(OOJS_ARGV[0]), &target)))
 	{
@@ -2229,30 +2230,21 @@ static JSBool ShipAddCargoEntity(JSContext *context, uintN argc, jsval *vp)
 		OOJSReportWarningForCaller(context, @"PlayerShip", @"addCargoEntity", @"Scoopable entity not in flight.");
 		return NO;
 	}
-	if (argc >= 2 && EXPECT_NOT(!JS_ValueToBoolean(context, OOJS_ARGV[1], &proc_events)))
+	if (argc >= 2 && EXPECT_NOT(!JS_ValueToBoolean(context, OOJS_ARGV[1], &procEvents)))
 	{
 		OOJSReportBadArguments(context, @"PlayerShip", @"addCargoEntity", MIN(argc, 2U), OOJS_ARGV, nil, @"boolean");
 		return NO;
 	}
-	if (argc == 3 && EXPECT_NOT(!JS_ValueToBoolean(context, OOJS_ARGV[2], &proc_messages)))
+	if (argc == 3 && EXPECT_NOT(!JS_ValueToBoolean(context, OOJS_ARGV[2], &procMessages)))
 	{
 		OOJSReportBadArguments(context, @"PlayerShip", @"addCargoEntity", MIN(argc, 3U), OOJS_ARGV, nil, @"boolean");
 		return NO;
 	}
 	
-	// scoop the object, but don't process any events/messages
-	if (proc_events && proc_messages) 
-	{
-		[thisEnt scoopUpProcess:target processEvents:YES processMessages:YES];
-	}
-	if (proc_events && !proc_messages) 
-	{
-		[thisEnt scoopUpProcess:target processEvents:YES processMessages:NO];
-	}
-	if (!proc_events && !proc_messages) 
-	{
-		[thisEnt scoopUpProcess:target processEvents:NO processMessages:NO];
-	}
+	// scoop the object, but don't process any events/messages unless requested
+	OOJS_BEGIN_FULL_NATIVE(context)
+	[thisEnt scoopUpProcess:target processEvents:procEvents processMessages:procMessages];
+	OOJS_END_FULL_NATIVE
 
 	OOJS_RETURN_BOOL([target status] == STATUS_IN_HOLD);
 

--- a/src/Core/Scripting/OOJSShip.m
+++ b/src/Core/Scripting/OOJSShip.m
@@ -70,6 +70,7 @@ static JSBool ShipHasRole(JSContext *context, uintN argc, jsval *vp);
 static JSBool ShipEjectItem(JSContext *context, uintN argc, jsval *vp);
 static JSBool ShipEjectSpecificItem(JSContext *context, uintN argc, jsval *vp);
 static JSBool ShipDumpCargo(JSContext *context, uintN argc, jsval *vp);
+static JSBool ShipAddCargoEntity(JSContext *context, uintN argc, jsval *vp);
 static JSBool ShipSpawn(JSContext *context, uintN argc, jsval *vp);
 static JSBool ShipDealEnergyDamage(JSContext *context, uintN argc, jsval *vp);
 static JSBool ShipExplode(JSContext *context, uintN argc, jsval *vp);
@@ -483,6 +484,7 @@ static JSFunctionSpec sShipMethods[] =
 {
 	// JS name					Function					min args
 	{ "abandonShip",			ShipAbandonShip,			0 },
+	{ "addCargoEntity",			ShipAddCargoEntity,			1 },
 	{ "addCollisionException",	ShipAddCollisionException,	1 },
 	{ "addDefenseTarget",		ShipAddDefenseTarget,		1 },
 	{ "adjustCargo",			ShipAdjustCargo,			2 },
@@ -2190,6 +2192,59 @@ static JSBool ShipEjectItem(JSContext *context, uintN argc, jsval *vp)
 	
 	OOJS_RETURN_OBJECT([thisEnt ejectShipOfRole:role]);
 	
+	OOJS_NATIVE_EXIT
+}
+
+
+// addCargoEntity: ship
+static JSBool ShipAddCargoEntity(JSContext *context, uintN argc, jsval *vp)
+{
+	OOJS_NATIVE_ENTER(context)
+	ShipEntity				*thisEnt = nil;
+	ShipEntity              *target = nil;
+	BOOL					proc_events = NO;
+	BOOL					proc_messages = NO;
+
+	GET_THIS_SHIP(thisEnt);
+
+	if (EXPECT_NOT([thisEnt isPlayer] && [(PlayerEntity *)thisEnt isDocked]))
+	{
+		OOJSReportWarningForCaller(context, @"PlayerShip", @"addCargoEntity", @"Can't add cargo entity while docked, ignoring.");
+		return NO;
+	}
+	if (EXPECT_NOT(argc == 0 ||
+				   !JSVAL_IS_OBJECT(OOJS_ARGV[0]) ||
+				   !JSShipGetShipEntity(context, JSVAL_TO_OBJECT(OOJS_ARGV[0]), &target)))
+	{
+		OOJSReportBadArguments(context, @"PlayerShip", @"addCargoEntity", argc, OOJS_ARGV, nil, @"scoopable entity.");
+		return NO;
+	}
+	if ([target scanClass] != CLASS_CARGO) 
+	{
+		OOJSReportWarningForCaller(context, @"PlayerShip", @"addCargoEntity", @"Scoopable entity not cargo.");
+		return NO;
+	}
+	if ([target status] != STATUS_IN_FLIGHT) 
+	{
+		OOJSReportWarningForCaller(context, @"PlayerShip", @"addCargoEntity", @"Scoopable entity not in flight.");
+		return NO;
+	}
+	if (argc >= 2 && EXPECT_NOT(!JS_ValueToBoolean(context, OOJS_ARGV[1], &proc_events)))
+	{
+		OOJSReportBadArguments(context, @"PlayerShip", @"addCargoEntity", argc, OOJS_ARGV, nil, @"boolean");
+		return NO;
+	}
+	if (argc == 3 && EXPECT_NOT(!JS_ValueToBoolean(context, OOJS_ARGV[2], &proc_messages)))
+	{
+		OOJSReportBadArguments(context, @"PlayerShip", @"addCargoEntity", argc, OOJS_ARGV, nil, @"boolean");
+		return NO;
+	}
+	
+	// scoop the object, but don't process any events/messages
+	[thisEnt scoopUpProcess:target processEvents:proc_events processMessages:proc_messages];
+
+	OOJS_RETURN_BOOL([target status] == STATUS_IN_HOLD);
+
 	OOJS_NATIVE_EXIT
 }
 

--- a/src/Core/Scripting/OOJSShip.m
+++ b/src/Core/Scripting/OOJSShip.m
@@ -2202,8 +2202,8 @@ static JSBool ShipAddCargoEntity(JSContext *context, uintN argc, jsval *vp)
 	OOJS_NATIVE_ENTER(context)
 	ShipEntity				*thisEnt = nil;
 	ShipEntity              *target = nil;
-	BOOL					proc_events = NO;
-	BOOL					proc_messages = NO;
+	JSBool					proc_events = NO;
+	JSBool					proc_messages = NO;
 
 	GET_THIS_SHIP(thisEnt);
 
@@ -2216,7 +2216,7 @@ static JSBool ShipAddCargoEntity(JSContext *context, uintN argc, jsval *vp)
 				   !JSVAL_IS_OBJECT(OOJS_ARGV[0]) ||
 				   !JSShipGetShipEntity(context, JSVAL_TO_OBJECT(OOJS_ARGV[0]), &target)))
 	{
-		OOJSReportBadArguments(context, @"PlayerShip", @"addCargoEntity", argc, OOJS_ARGV, nil, @"scoopable entity.");
+		OOJSReportBadArguments(context, @"PlayerShip", @"addCargoEntity", MIN(argc, 1U), OOJS_ARGV, nil, @"scoopable entity.");
 		return NO;
 	}
 	if ([target scanClass] != CLASS_CARGO) 
@@ -2231,17 +2231,28 @@ static JSBool ShipAddCargoEntity(JSContext *context, uintN argc, jsval *vp)
 	}
 	if (argc >= 2 && EXPECT_NOT(!JS_ValueToBoolean(context, OOJS_ARGV[1], &proc_events)))
 	{
-		OOJSReportBadArguments(context, @"PlayerShip", @"addCargoEntity", argc, OOJS_ARGV, nil, @"boolean");
+		OOJSReportBadArguments(context, @"PlayerShip", @"addCargoEntity", MIN(argc, 2U), OOJS_ARGV, nil, @"boolean");
 		return NO;
 	}
 	if (argc == 3 && EXPECT_NOT(!JS_ValueToBoolean(context, OOJS_ARGV[2], &proc_messages)))
 	{
-		OOJSReportBadArguments(context, @"PlayerShip", @"addCargoEntity", argc, OOJS_ARGV, nil, @"boolean");
+		OOJSReportBadArguments(context, @"PlayerShip", @"addCargoEntity", MIN(argc, 3U), OOJS_ARGV, nil, @"boolean");
 		return NO;
 	}
 	
 	// scoop the object, but don't process any events/messages
-	[thisEnt scoopUpProcess:target processEvents:proc_events processMessages:proc_messages];
+	if (proc_events && proc_messages) 
+	{
+		[thisEnt scoopUpProcess:target processEvents:YES processMessages:YES];
+	}
+	if (proc_events && !proc_messages) 
+	{
+		[thisEnt scoopUpProcess:target processEvents:YES processMessages:NO];
+	}
+	if (!proc_events && !proc_messages) 
+	{
+		[thisEnt scoopUpProcess:target processEvents:NO processMessages:NO];
+	}
 
 	OOJS_RETURN_BOOL([target status] == STATUS_IN_HOLD);
 


### PR DESCRIPTION
This adds the "addCargoEntity" to the player ship, allowing cargo entities to be added directly to the players cargo hold. 1 required param (the actual cargo entity, which must be a valid cargo entity currently in space somewhere), 2 optional params: processEvents (bool, default false) to indicate whether normal scooping events (eg shipScoopedOther) should be executed; processMessages (bool, default false) to indicate whether normal scooping messages (eg "You rescued Bill Gates")  should be displayed.