### PR TITLE
Adds events and controls for MFDs and primed equipment

### DIFF
--- a/src/Core/Entities/PlayerEntity.h
+++ b/src/Core/Entities/PlayerEntity.h
@@ -990,7 +990,7 @@ typedef enum
 
 - (void) setGuiToStatusScreen;
 - (NSArray *) equipmentList;	// Each entry is an array with a string followed by a boolean indicating availability (NO = damaged).
-- (void) setPrimedEquipment:(NSString *)eqKey;
+- (BOOL) setPrimedEquipment:(NSString *)eqKey;
 - (NSString *) primedEquipmentName:(NSInteger)offset;
 - (NSUInteger) primedEquipmentCount;
 - (void) activatePrimableEquipment:(NSUInteger)index withMode:(OOPrimedEquipmentMode)mode;

--- a/src/Core/Entities/PlayerEntity.h
+++ b/src/Core/Entities/PlayerEntity.h
@@ -990,6 +990,7 @@ typedef enum
 
 - (void) setGuiToStatusScreen;
 - (NSArray *) equipmentList;	// Each entry is an array with a string followed by a boolean indicating availability (NO = damaged).
+- (void) setPrimedEquipment:(NSString *)eqKey;
 - (NSString *) primedEquipmentName:(NSInteger)offset;
 - (NSUInteger) primedEquipmentCount;
 - (void) activatePrimableEquipment:(NSUInteger)index withMode:(OOPrimedEquipmentMode)mode;

--- a/src/Core/Entities/PlayerEntity.h
+++ b/src/Core/Entities/PlayerEntity.h
@@ -990,7 +990,7 @@ typedef enum
 
 - (void) setGuiToStatusScreen;
 - (NSArray *) equipmentList;	// Each entry is an array with a string followed by a boolean indicating availability (NO = damaged).
-- (BOOL) setPrimedEquipment:(NSString *)eqKey;
+- (BOOL) setPrimedEquipment:(NSString *)eqKey showMessage:(BOOL)showMsg;
 - (NSString *) primedEquipmentName:(NSInteger)offset;
 - (NSUInteger) primedEquipmentCount;
 - (void) activatePrimableEquipment:(NSUInteger)index withMode:(OOPrimedEquipmentMode)mode;

--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -7913,8 +7913,21 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 
 - (BOOL) setPrimedEquipment:(NSString *)eqKey
 {
+	NSUInteger c = [eqScripts count];
+	NSUInteger current = primedEquipment;
 	primedEquipment = [self eqScriptIndexForKey:eqKey];	// if key not found primedEquipment is set to primed-none
-	return (primedEquipment != [eqScripts count]);
+	BOOL result = YES;
+	if (primedEquipment == c)
+	{
+		primedEquipment = current;
+		result = NO;
+	}
+	else 
+	{
+		NSString *equipmentName = [[OOEquipmentType equipmentTypeWithIdentifier:[[eqScripts oo_arrayAtIndex:primedEquipment] oo_stringAtIndex:0]] name];
+		[UNIVERSE addMessage:OOExpandKey(@"equipment-primed", equipmentName) forCount:2.0];
+	}
+	return result;
 }
 
 

--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -5376,6 +5376,7 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 - (void) cycleMultiFunctionDisplay:(NSUInteger) index
 {
 	NSArray *keys = [multiFunctionDisplayText allKeys];
+	NSString *key = nil;
 	if ([keys count] == 0)
 	{
 		[self setMultiFunctionDisplay:index toKey:nil];
@@ -5384,20 +5385,27 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 	id current = [multiFunctionDisplaySettings objectAtIndex:index];
 	if (current == [NSNull null])
 	{
-		[self setMultiFunctionDisplay:index toKey:[keys objectAtIndex:0]];
+		key = [keys objectAtIndex:0];
+		[self setMultiFunctionDisplay:index toKey:key];
 	}
 	else
 	{
 		NSUInteger cIndex = [keys indexOfObject:current];
 		if (cIndex == NSNotFound || cIndex + 1 >= [keys count])
 		{
+			key = nil;
 			[self setMultiFunctionDisplay:index toKey:nil];
 		}
 		else 
 		{
-			[self setMultiFunctionDisplay:index toKey:[keys objectAtIndex:(cIndex+1)]];
+			key = [keys objectAtIndex:(cIndex+1)];
+			[self setMultiFunctionDisplay:index toKey:key];
 		}
 	}
+	JSContext *context = OOJSAcquireContext();
+	jsval keyVal = OOJSValueFromNativeObject(context,key);
+	ShipScriptEvent(context, self, "mfdKeyChanged", INT_TO_JSVAL(activeMFD), keyVal);
+	OOJSRelinquishContext(context);
 }
 
 
@@ -5406,6 +5414,9 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 	activeMFD = (activeMFD + 1) % [[self hud] mfdCount];
 	NSUInteger mfdID = activeMFD + 1;
 	[UNIVERSE addMessage:OOExpandKey(@"mfd-N-selected", mfdID) forCount:3.0 ];
+	JSContext *context = OOJSAcquireContext();
+	ShipScriptEvent(context, self, "selectedMFDChanged", INT_TO_JSVAL(activeMFD));
+	OOJSRelinquishContext(context);
 }
 
 
@@ -7897,6 +7908,12 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 	{
 		return [[OOEquipmentType equipmentTypeWithIdentifier:[[eqScripts oo_arrayAtIndex:idx] oo_stringAtIndex:0]] name];
 	}
+}
+
+
+- (void) setPrimedEquipment:(NSString *)eqKey
+{
+	primedEquipment = [self eqScriptIndexForKey:eqKey];	// if key not found primedEquipment is set to primed-none
 }
 
 

--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -7911,9 +7911,10 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 }
 
 
-- (void) setPrimedEquipment:(NSString *)eqKey
+- (BOOL) setPrimedEquipment:(NSString *)eqKey
 {
 	primedEquipment = [self eqScriptIndexForKey:eqKey];	// if key not found primedEquipment is set to primed-none
+	return (primedEquipment != [eqScripts count]);
 }
 
 

--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -7911,21 +7911,24 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 }
 
 
-- (BOOL) setPrimedEquipment:(NSString *)eqKey
+- (BOOL) setPrimedEquipment:(NSString *)eqKey showMessage:(BOOL)showMsg
 {
 	NSUInteger c = [eqScripts count];
 	NSUInteger current = primedEquipment;
 	primedEquipment = [self eqScriptIndexForKey:eqKey];	// if key not found primedEquipment is set to primed-none
 	BOOL result = YES;
-	if (primedEquipment == c)
+	if (primedEquipment == c && ![eqKey isEqualToString:@""])
 	{
 		primedEquipment = current;
 		result = NO;
 	}
 	else 
 	{
-		NSString *equipmentName = [[OOEquipmentType equipmentTypeWithIdentifier:[[eqScripts oo_arrayAtIndex:primedEquipment] oo_stringAtIndex:0]] name];
-		[UNIVERSE addMessage:OOExpandKey(@"equipment-primed", equipmentName) forCount:2.0];
+		if (showMsg == YES)
+		{
+			NSString *equipmentName = [[OOEquipmentType equipmentTypeWithIdentifier:[[eqScripts oo_arrayAtIndex:primedEquipment] oo_stringAtIndex:0]] name];
+			[UNIVERSE addMessage:[eqKey isEqualToString:@""] ? OOExpandKey(@"equipment-primed-none") : OOExpandKey(@"equipment-primed", equipmentName) forCount:2.0];
+		}
 	}
 	return result;
 }

--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -7916,18 +7916,20 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 	NSUInteger c = [eqScripts count];
 	NSUInteger current = primedEquipment;
 	primedEquipment = [self eqScriptIndexForKey:eqKey];	// if key not found primedEquipment is set to primed-none
+	BOOL unprimeEq = [eqKey isEqualToString:@""];
 	BOOL result = YES;
-	if (primedEquipment == c && ![eqKey isEqualToString:@""])
+
+	if (primedEquipment == c && !unprimeEq)
 	{
 		primedEquipment = current;
 		result = NO;
 	}
 	else 
 	{
-		if (showMsg == YES)
+		if (primedEquipment != current && showMsg == YES)
 		{
 			NSString *equipmentName = [[OOEquipmentType equipmentTypeWithIdentifier:[[eqScripts oo_arrayAtIndex:primedEquipment] oo_stringAtIndex:0]] name];
-			[UNIVERSE addMessage:[eqKey isEqualToString:@""] ? OOExpandKey(@"equipment-primed-none") : OOExpandKey(@"equipment-primed", equipmentName) forCount:2.0];
+			[UNIVERSE addMessage:unprimeEq ? OOExpandKey(@"equipment-primed-none") : OOExpandKey(@"equipment-primed", equipmentName) forCount:2.0];
 		}
 	}
 	return result;

--- a/src/Core/Scripting/OOJSPlayerShip.m
+++ b/src/Core/Scripting/OOJSPlayerShip.m
@@ -1520,9 +1520,8 @@ static JSBool PlayerShipSetPrimedEquipment(JSContext *context, uintN argc, jsval
 		OOJSReportBadArguments(context, @"PlayerShip", @"setPrimedEquipment", MIN(argc, 1U), OOJS_ARGV, nil, @"string (key)");
 		return NO;
 	}
-	[player setPrimedEquipment:key];
-
-	OOJS_RETURN_VOID;
+	
+	OOJS_RETURN_BOOL([player setPrimedEquipment:key]);
 
 	OOJS_NATIVE_EXIT
 }

--- a/src/Core/Scripting/OOJSPlayerShip.m
+++ b/src/Core/Scripting/OOJSPlayerShip.m
@@ -1503,13 +1503,15 @@ static JSBool PlayerShipSetMultiFunctionText(JSContext *context, uintN argc, jsv
 }
 
 
-// setPrimedEquipment(key)
+// setPrimedEquipment(key, [noMessage])
 static JSBool PlayerShipSetPrimedEquipment(JSContext *context, uintN argc, jsval *vp)
 {
 	OOJS_NATIVE_ENTER(context)
 
 	NSString				*key = nil;
 	PlayerEntity			*player = OOPlayerForScripting();
+	JSBool					showMsg = YES;
+	BOOL					result = NO;
 
 	if (argc > 0)  
 	{
@@ -1520,8 +1522,14 @@ static JSBool PlayerShipSetPrimedEquipment(JSContext *context, uintN argc, jsval
 		OOJSReportBadArguments(context, @"PlayerShip", @"setPrimedEquipment", MIN(argc, 1U), OOJS_ARGV, nil, @"string (key)");
 		return NO;
 	}
-	
-	OOJS_RETURN_BOOL([player setPrimedEquipment:key]);
+	if (argc > 1 && EXPECT_NOT(!JS_ValueToBoolean(context, OOJS_ARGV[1], &showMsg)))
+ 	{
+ 		OOJSReportBadArguments(context, @"PlayerShip", @"setPrimedEquipment", MIN(argc, 2U), OOJS_ARGV, nil, @"boolean");
+ 		return NO;
+ 	}
+
+	result = [player setPrimedEquipment:key showMessage:showMsg];
+	OOJS_RETURN_BOOL(result);
 
 	OOJS_NATIVE_EXIT
 }

--- a/src/Core/Scripting/OOJSPlayerShip.m
+++ b/src/Core/Scripting/OOJSPlayerShip.m
@@ -68,6 +68,7 @@ static JSBool PlayerShipRemoveParcel(JSContext *context, uintN argc, jsval *vp);
 static JSBool PlayerShipAwardContract(JSContext *context, uintN argc, jsval *vp);
 static JSBool PlayerShipRemoveContract(JSContext *context, uintN argc, jsval *vp);
 static JSBool PlayerShipSetCustomView(JSContext *context, uintN argc, jsval *vp);
+static JSBool PlayerShipSetPrimedEquipment(JSContext *context, uintN argc, jsval *vp);
 static JSBool PlayerShipResetCustomView(JSContext *context, uintN argc, jsval *vp);
 static JSBool PlayerShipResetScannerZoom(JSContext *context, uintN argc, jsval *vp);
 static JSBool PlayerShipTakeInternalDamage(JSContext *context, uintN argc, jsval *vp);
@@ -246,6 +247,7 @@ static JSFunctionSpec sPlayerShipMethods[] =
 	{ "setCustomHUDDial",				PlayerShipSetCustomHUDDial,					2 },
 	{ "setMultiFunctionDisplay",		PlayerShipSetMultiFunctionDisplay,			1 },
 	{ "setMultiFunctionText",			PlayerShipSetMultiFunctionText,				1 },
+	{ "setPrimedEquipment",				PlayerShipSetPrimedEquipment,               1 },
 	{ "showHUDSelector",				PlayerShipShowHUDSelector,					1 },
 	{ "takeInternalDamage",				PlayerShipTakeInternalDamage,				0 },
 	{ "useSpecialCargo",				PlayerShipUseSpecialCargo,					1 },
@@ -1494,6 +1496,31 @@ static JSBool PlayerShipSetMultiFunctionText(JSContext *context, uintN argc, jsv
 		NSString *formatted = [gui reflowTextForMFD:value];
 		[player setMultiFunctionText:formatted forKey:key];
 	}
+
+	OOJS_RETURN_VOID;
+
+	OOJS_NATIVE_EXIT
+}
+
+
+// setPrimedEquipment(key)
+static JSBool PlayerShipSetPrimedEquipment(JSContext *context, uintN argc, jsval *vp)
+{
+	OOJS_NATIVE_ENTER(context)
+
+	NSString				*key = nil;
+	PlayerEntity			*player = OOPlayerForScripting();
+
+	if (argc > 0)  
+	{
+		key = OOStringFromJSValue(context, OOJS_ARGV[0]);
+	}
+	if (key == nil)
+	{
+		OOJSReportBadArguments(context, @"PlayerShip", @"setPrimedEquipment", MIN(argc, 1U), OOJS_ARGV, nil, @"string (key)");
+		return NO;
+	}
+	[player setPrimedEquipment:key];
 
 	OOJS_RETURN_VOID;
 

--- a/src/Core/Scripting/OOJSPlayerShip.m
+++ b/src/Core/Scripting/OOJSPlayerShip.m
@@ -1511,7 +1511,6 @@ static JSBool PlayerShipSetPrimedEquipment(JSContext *context, uintN argc, jsval
 	NSString				*key = nil;
 	PlayerEntity			*player = OOPlayerForScripting();
 	JSBool					showMsg = YES;
-	BOOL					result = NO;
 
 	if (argc > 0)  
 	{
@@ -1528,8 +1527,7 @@ static JSBool PlayerShipSetPrimedEquipment(JSContext *context, uintN argc, jsval
  		return NO;
  	}
 
-	result = [player setPrimedEquipment:key showMessage:showMsg];
-	OOJS_RETURN_BOOL(result);
+	OOJS_RETURN_BOOL([player setPrimedEquipment:key showMessage:showMsg]);
 
 	OOJS_NATIVE_EXIT
 }


### PR DESCRIPTION
This update hopefully provides the events and methods that will allow OXP devs to automatically prime a piece of equipment whenever an MFD is selected or changed by the player. There are two new events (selectedMFDChanged and mfdKeyChanged) and one new method (player.ship.setPrimedEquipment). 