### PR TITLE
Bumps Copyright year to 2017

### DIFF
--- a/Doc/LICENSE.TXT
+++ b/Doc/LICENSE.TXT
@@ -1,4 +1,4 @@
-Copyright © 2004-2011 Giles C Williams and contributors.
+Copyright © 2004-2017 Giles C Williams and contributors.
 
 This work is licensed under the GNU General Public License version 2.
 


### PR DESCRIPTION
Copyright line in license says 2004-2011.
Changed 2011 into 2017 as that is the current year