### PR TITLE
Introducing the %G###### string expander. It works like the %J### one…

### DIFF
--- a/Resources/Config/missiontext.plist
+++ b/Resources/Config/missiontext.plist
@@ -14,9 +14,9 @@
 	
 	"constrictor_hunt_brief1" = "---INCOMING MESSAGE\n\nGreetings Commander,\n\nI am Captain Curruthers of Her Imperial Majesty’s Space Navy and I beg a moment of your valuable time. We would like you to do a little job for us.\nThe ship you see here is a new model, the Constrictor, equipped with a top secret new shield generator.\n\nUnfortunately it’s been stolen.\n";
 	"constrictor_hunt_brief1a" = "It went missing from our ship yard on %J150 five months ago and was last seen at %J036. Your mission, should you decide to accept it, is to seek and destroy this ship. You are cautioned that only Military Lasers will get through the new shields and that the Constrictor is fitted with an E.C.M. System.\n\nGood Luck, Commander.\n\n---MESSAGE ENDS.";
-	"constrictor_hunt_brief1b" = "It went missing from Xeer Shipyards five months ago and is believed to have jumped to this galaxy. Your mission, should you decide to accept it, is to seek and destroy this ship. You are cautioned that only Military Lasers will get through the new shields and that the Constrictor is fitted with an E.C.M. System.\n\nGood Luck, Commander.\n\n---MESSAGE ENDS.";
+	"constrictor_hunt_brief1b" = "It went missing from %G150000 Shipyards five months ago and is believed to have jumped to this galaxy. Your mission, should you decide to accept it, is to seek and destroy this ship. You are cautioned that only Military Lasers will get through the new shields and that the Constrictor is fitted with an E.C.M. System.\n\nGood Luck, Commander.\n\n---MESSAGE ENDS.";
 	"constrictor_hunt_info1a" = "Hunt for the Constrictor stolen from %J150.";
-	"constrictor_hunt_info1b" = "Hunt for the Constrictor stolen from Xeer Shipyards.";
+	"constrictor_hunt_info1b" = "Hunt for the Constrictor stolen from %G150000 Shipyards.";
 	"constrictor_hunt_debrief" = "---INCOMING MESSAGE\n\nCongratulations Commander!\n\nThere will always be a place for you in Her Imperial Majesty’s Space Navy.\n\nAnd maybe sooner than you think…\n\n---MESSAGE ENDS.";
 	"constrictor_hunt_thief_captured" = "You captured the thief who stole the constrictor! Her Imperial Navy awards you a bonus of 1000 credits!\n";
 	"constrictor_hunt_thief_captured2" = "You captured an empty escape pod. The thief who stole the constrictor is still on board and you left the ship intact! Her Imperial Navy gives you a second chance!\n";

--- a/src/Core/OOStringExpander.h
+++ b/src/Core/OOStringExpander.h
@@ -90,6 +90,9 @@ typedef NSUInteger OOExpandOptions;
 	  * %R is like %N but, due to a bug, misses some possibilities. Deprecated.
 	  * %JNNN, where NNN is a three-digit integer, is replaced with the name
 	    of system ID NNN in the current galaxy.
+	  * %GNNNNNN, where NNNNNN is a six-digit integer, is replaced with the
+	    name of system ID NNN (first triplet) in the specified galaxy
+	    (second triplet).
 	  * %% is replaced with %.
 	  * %[ is replaced with [.
 	  * %] is replaced with ].

--- a/src/Core/Universe.h
+++ b/src/Core/Universe.h
@@ -638,6 +638,7 @@ enum
 - (id) systemDataForGalaxy:(OOGalaxyID) gnum planet:(OOSystemID) pnum key:(NSString *)key;
 - (NSArray *) systemDataKeysForGalaxy:(OOGalaxyID)gnum planet:(OOSystemID)pnum;
 - (NSString *) getSystemName:(OOSystemID) sys;
+- (NSString *) getSystemName:(OOSystemID) sys forGalaxy:(OOGalaxyID) gnum;
 - (OOGovernmentID) getSystemGovernment:(OOSystemID) sys;
 - (NSString *) getSystemInhabitants:(OOSystemID) sys;
 - (NSString *) getSystemInhabitants:(OOSystemID) sys plural:(BOOL)plural;

--- a/src/Core/Universe.m
+++ b/src/Core/Universe.m
@@ -7790,7 +7790,13 @@ static void VerifyDesc(NSString *key, id desc)
 
 - (NSString *) getSystemName:(OOSystemID) sys
 {
-	return [systemManager getProperty:@"name" forSystem:sys inGalaxy:galaxyID];
+	return [self getSystemName:sys forGalaxy:galaxyID];
+}
+
+
+- (NSString *) getSystemName:(OOSystemID) sys forGalaxy:(OOGalaxyID) gnum
+{
+	return [systemManager getProperty:@"name" forSystem:sys inGalaxy:gnum];
 }
 
 
@@ -10240,7 +10246,8 @@ static void PreloadOneSound(NSString *soundName)
 	 @"\tpercent_I [label=\"%I\\nInhabitants\" shape=diamond]\n"
 	 "\tpercent_H [label=\"%H\\nSystem name\" shape=diamond]\n"
 	 "\tpercent_RN [label=\"%R/%N\\nRandom name\" shape=diamond]\n"
-	 "\tpercent_J [label=\"%J\\nNumbered system name\" shape=diamond]\n\t\n"];
+	 "\tpercent_J [label=\"%J\\nNumbered system name\" shape=diamond]\n"
+	 "\tpercent_G [label=\"%G\\nNumbered system name in chart number\" shape=diamond]\n\t\n"];
 	
 	// Toss in the Thargoid curses, too
 	[graphViz appendString:@"\tsubgraph cluster_thargoid_curses\n\t{\n\t\tlabel = \"Thargoid curses\"\n"];
@@ -10349,10 +10356,15 @@ static void PreloadOneSound(NSString *soundName)
 		[graphViz appendFormat:@"\t%@ -> percent_RN [color=\"0,0,0.65\"]\n", fromNode];
 	}
 	
-	// TODO: test graphViz output for @"%Jxxx"
+	// TODO: test graphViz output for @"%Jxxx" and @"%Gxxxxxx"
 	if ([string rangeOfString:@"%J"].location != NSNotFound)
 	{
 		[graphViz appendFormat:@"\t%@ -> percent_J [color=\"0,0,0.75\"]\n", fromNode];
+	}
+	
+	if ([string rangeOfString:@"%G"].location != NSNotFound)
+	{
+		[graphViz appendFormat:@"\t%@ -> percent_G [color=\"0,0,0.85\"]\n", fromNode];
 	}
 }
 


### PR DESCRIPTION
…, but it takes two triplets of numbers rather than one, namely the system ID followed by the galaxy ID. This way we can refer to planet names in galaxies other than where the player is. %J### remains for compatibility reasons. Updated Constrictor Hunt mission strings to eliminate hard coded references to Xeer in the mission texts.