### PR TITLE
Optimization: Explosion Culling

### DIFF
--- a/src/Core/Entities/ShipEntity.m
+++ b/src/Core/Entities/ShipEntity.m
@@ -9192,7 +9192,7 @@ NSComparisonResult ComparePlanetsBySurfaceDistance(id i1, id i2, void* context)
 	{
 		if ([self isThargoid] && [roleSet hasRole:@"thargoid-mothership"])  [self broadcastThargoidDestroyed];
 		
-		if (!suppressExplosion)
+		if (!suppressExplosion && ([self isVisible] || HPdistance2([self position], [PLAYER position]) < SCANNER_MAX_RANGE2))
 		{
 			if (!isWreckage && mass > 500000.0f && randf() < 0.25f) // big!
 			{


### PR DESCRIPTION
You may have noticed already that, sometimes, entity count jumps quite a bit, then drops quickly back down to its previous levels. This is often due to explosions. They tend to generate a number of entities that are added to the universe at the moment of the explosion and are removed shortly after, once their life has expired. This happens every time as part of the simulation, regardless of where the explosion takes place. Very often, the amount of entities being generated results in momentary stutter.

This change tries to minimize the side effects of explosions happening. We now generate all those extra entities only if the object that exploded was visible in the first place. Regardless of visibility, the explosion is rendered normally if it has happened within scanner range (so e.g. an escape pod exploding will always have a visible explosion, although it stops being visible past 5000m or so).

Initial testing indicates that long distance battles are still noticeable like before. This is because most ship entities have visibility ranges well beyond scanner range. However, some exaggerations we have now are avoided. Up to now, the explosion of an Anaconda going off next to the station could be seen from the witchpoint, which strikes me as kind of silly and does not help with the sense of scale much.

So, we will hopefully now have a bit better performance by not generating way too distant entities, but because I consider this change not such a trivial one, I'd like some feedback from your side. During my tests, I also noticed a very rare case of crashing while loading a saved game, which may or may not be related; I can't see why the proposed change might cause crashes, but I did not have any crashes at all before, so... please check if you can.