### PR TITLE
Check energy

### DIFF
--- a/src/Core/Entities/ShipEntityAI.m
+++ b/src/Core/Entities/ShipEntityAI.m
@@ -1510,6 +1510,11 @@
 
 - (void) checkEnergy
 {
+    if (maxEnergy < energy < 0)
+    {
+		NSLog(@"Energy level reported has taken on an invalid value.");
+		return;
+    }
 	if (energy == maxEnergy)
 	{
 		[shipAI message:@"ENERGY_FULL"];
@@ -1520,12 +1525,21 @@
 		[shipAI message:@"ENERGY_HIGH"];
 		return;
 	}
-	if (energy <= maxEnergy * 0.25)
+	if (energy >= maxEnergy * 0.25)
+	{
+		[shipAI message:@"ENERGY_MEDIUM"];
+		return;
+	}
+	if (energy > 0)
 	{
 		[shipAI message:@"ENERGY_LOW"];
 		return;
 	}
-	[shipAI message:@"ENERGY_MEDIUM"];
+	if (energy == 0)
+	{
+		[shipAI message:@"ENERGY_GONE"];
+		return;
+	}
 }
 
 - (void) checkHeatInsulation


### PR DESCRIPTION
Provides an explicit check to [checkEnergy](https://github.com/OoliteProject/oolite/blob/1.88/src/Core/Entities/ShipEntityAI.m#L1511) for both the outer bounds and the Medium Energy level. Also adds message `ENERGY_GONE` when depleted.