### PR TITLE
Enable toggling HUD during gameplay

### DIFF
--- a/src/Core/Entities/PlayerEntityControls.m
+++ b/src/Core/Entities/PlayerEntityControls.m
@@ -780,7 +780,7 @@ static NSTimeInterval	time_last_frame;
 		}
 		
 		// HUD toggle
-		if ([gameView isDown:key_hud_toggle] && [gameController isGamePaused])	// 'o' key while paused
+		if ([gameView isDown:key_hud_toggle])
 		{
 			exceptionContext = @"toggle HUD";
 			if (!hide_hud_pressed)


### PR DESCRIPTION
This change enables the HUD to be toggled any time with the "o" key. Previously this was restricted to the pause menu only. This effect is quite different from the other Debugging Keys and makes more sense to enable this to be toggled at all times.

#322 