### PR TITLE
Station shipyard bugfix

### DIFF
--- a/src/Core/Entities/PlayerEntityContracts.m
+++ b/src/Core/Entities/PlayerEntityContracts.m
@@ -1771,9 +1771,6 @@ static NSMutableDictionary *currentShipyard = nil;
 	OOCreditsQuantity price = [shipInfo oo_unsignedLongLongForKey:SHIPYARD_KEY_PRICE];
 	OOCreditsQuantity tradeIn = [self tradeInValue];
 
-	// make sure these two values are always different
-	if (tradeIn == (price * 10)) tradeIn += 1;
-
 	if (credits + tradeIn < price * 10)
 		return NO;	// you can't afford it!
 	

--- a/src/Core/Entities/PlayerEntityContracts.m
+++ b/src/Core/Entities/PlayerEntityContracts.m
@@ -1771,6 +1771,8 @@ static NSMutableDictionary *currentShipyard = nil;
 	OOCreditsQuantity price = [shipInfo oo_unsignedLongLongForKey:SHIPYARD_KEY_PRICE];
 	OOCreditsQuantity tradeIn = [self tradeInValue];
 
+	// make sure these two values are always different
+	if (tradeIn == (price * 10)) tradeIn += 1;
 
 	if (credits + tradeIn < price * 10)
 		return NO;	// you can't afford it!

--- a/src/Core/Entities/PlayerEntityControls.m
+++ b/src/Core/Entities/PlayerEntityControls.m
@@ -2666,10 +2666,9 @@ static NSTimeInterval	time_last_frame;
 						shipprice = [self priceForShipKey:key];
 					}
 
-					OOCreditsQuantity money = credits;
 					if ([self buySelectedShip])
 					{
-						if (money != credits)	// money == credits means we skipped to another page, don't do anything
+						if (![key hasPrefix:@"More:"]) // don't do anything if we clicked/selected a "More:" line
 						{
 							[UNIVERSE removeDemoShips];
 							[self setGuiToStatusScreen];

--- a/src/Core/Scripting/OOJSStation.m
+++ b/src/Core/Scripting/OOJSStation.m
@@ -308,9 +308,17 @@ static JSBool StationGetProperty(JSContext *context, JSObject *this, jsid propID
 
 		case kStation_shipyard:
 		{
-			if ([entity localShipyard] == nil) [entity generateShipyard];
-			NSMutableArray *shipyard = [entity localShipyard];
-			*value = OOJSValueFromNativeObject(context, shipyard);
+			if (![entity hasShipyard]) 
+			{
+				// return null if station has no shipyard
+				*value = OOJSValueFromNativeObject(context, nil);
+			} 
+			else 
+			{
+				if ([entity localShipyard] == nil) [entity generateShipyard];
+				NSMutableArray *shipyard = [entity localShipyard];
+				*value = OOJSValueFromNativeObject(context, shipyard);
+			}
 			return YES;
 		}
 

--- a/src/Core/Scripting/OOJSStation.m
+++ b/src/Core/Scripting/OOJSStation.m
@@ -1087,12 +1087,8 @@ static JSBool StationAddShipToShipyard(JSContext *context, uintN argc, jsval *vp
 	[result setObject:extras forKey:KEY_EQUIPMENT_EXTRAS];
 	// add the ship spec
 	[result setObject:shipInfo forKey:SHIPYARD_KEY_SHIP];
-	
-	NSMutableDictionary	*resultDictionary = [NSMutableDictionary dictionary];
-	[resultDictionary setObject:result forKey:shipID];	// should order them fairly randomly
-
 	// add it to the station's shipyard
-	[shipyard addObject:resultDictionary];
+	[shipyard addObject:result];
 
 	// refresh the screen if the shipyard is currently being displayed
 	if(station == [PLAYER dockedStation] && [PLAYER guiScreen] == GUI_SCREEN_SHIPYARD)

--- a/src/Core/Scripting/OOJSStation.m
+++ b/src/Core/Scripting/OOJSStation.m
@@ -1087,8 +1087,12 @@ static JSBool StationAddShipToShipyard(JSContext *context, uintN argc, jsval *vp
 	[result setObject:extras forKey:KEY_EQUIPMENT_EXTRAS];
 	// add the ship spec
 	[result setObject:shipInfo forKey:SHIPYARD_KEY_SHIP];
+	
+	NSMutableDictionary	*resultDictionary = [NSMutableDictionary dictionary];
+	[resultDictionary setObject:result forKey:shipID];	// should order them fairly randomly
+
 	// add it to the station's shipyard
-	[shipyard addObject:result];
+	[shipyard addObject:resultDictionary];
 
 	// refresh the screen if the shipyard is currently being displayed
 	if(station == [PLAYER dockedStation] && [PLAYER guiScreen] == GUI_SCREEN_SHIPYARD)


### PR DESCRIPTION
Performing `station.shipyard` was generating shipyard entries even when `hasShipyard` was false. The shipyard wasn't ever visible to the player, but the data would be created unnecessarily.
This PR now returns a null value for `station.shipyard` if `hasShipyard` is false.