### PR TITLE
Adding EquipmentInfo.calculatedPrice property, adding 'paid' param to…

### DIFF
--- a/src/Core/Entities/PlayerEntity.h
+++ b/src/Core/Entities/PlayerEntity.h
@@ -1000,6 +1000,8 @@ typedef enum
 - (void) setFastEquipmentA:(NSString *)eqKey;
 - (void) setFastEquipmentB:(NSString *)eqKey;
 
+- (OOCreditsQuantity) adjustPriceByScriptForEqKey:(NSString *)eqKey withCurrent:(OOCreditsQuantity)price;
+
 - (NSArray *) cargoList;
 //- (NSArray *) cargoListForScripting; // now in ShipEntity
 - (unsigned) legalStatusOfCargoList;

--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -141,7 +141,6 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 - (void) showMarketCashAndLoadLine;
 
 
-- (OOCreditsQuantity) adjustPriceByScriptForEqKey:(NSString *)eqKey withCurrent:(OOCreditsQuantity)price;
 - (BOOL) tryBuyingItem:(NSString *)eqKey;
 
 // Cargo & passenger contracts
@@ -10123,7 +10122,7 @@ static NSString *last_outfitting_key=nil;
 				ship_clock_adjust += (double)adjust;
 			}
 			
-			[self doScriptEvent:OOJSID("playerBoughtEquipment") withArgument:key];
+			[self doScriptEvent:OOJSID("playerBoughtEquipment") withArguments:[NSArray arrayWithObjects:key, [NSNumber numberWithLongLong:(old_credits - credits)], nil]];
 			if (gui_screen == GUI_SCREEN_EQUIP_SHIP) //if we haven't changed gui screen inside playerBoughtEquipment
 			{ 
 				// show any change due to playerBoughtEquipment

--- a/src/Core/Scripting/OOJSEquipmentInfo.m
+++ b/src/Core/Scripting/OOJSEquipmentInfo.m
@@ -45,6 +45,7 @@ static JSBool EquipmentInfoStaticInfoForKey(JSContext *context, uintN argc, jsva
 enum
 {
 	// Property IDs
+	kEquipmentInfo_calculatedPrice,
 	kEquipmentInfo_canBeDamaged,
 	kEquipmentInfo_canCarryMultiple,
 	kEquipmentInfo_damageProbability,
@@ -83,6 +84,7 @@ enum
 static JSPropertySpec sEquipmentInfoProperties[] =
 {
 	// JS name							ID											flags
+	{ "calculatedPrice",				kEquipmentInfo_calculatedPrice,				OOJS_PROP_READONLY_CB },
 	{ "canBeDamaged",					kEquipmentInfo_canBeDamaged,				OOJS_PROP_READONLY_CB },
 	{ "canCarryMultiple",				kEquipmentInfo_canCarryMultiple,			OOJS_PROP_READONLY_CB },
 	{ "damageProbability",				kEquipmentInfo_damageProbability,			OOJS_PROP_READONLY_CB },
@@ -254,7 +256,20 @@ static JSBool EquipmentInfoGetProperty(JSContext *context, JSObject *this, jsid 
 		case kEquipmentInfo_name:
 			result = [eqType name];
 			break;
-			
+
+		case kEquipmentInfo_calculatedPrice:
+			if ([[eqType identifier] isEqual:@"EQ_FUEL"]) 
+			{
+				return JS_NewNumberValue(context, (PLAYER_MAX_FUEL - [OOPlayerForScripting() fuel]) * [eqType price] * [OOPlayerForScripting() fuelChargeRate], value);
+			}
+			else if ([[eqType identifier] isEqual:@"EQ_RENOVATION"]) 
+			{
+				return JS_NewNumberValue(context, [OOPlayerForScripting() renovationCosts], value);
+			}
+			else 
+			{
+				return JS_NewNumberValue(context, [OOPlayerForScripting() adjustPriceByScriptForEqKey:[eqType identifier] withCurrent:[eqType price]], value);
+			}
 		case kEquipmentInfo_canCarryMultiple:
 			*value = OOJSValueFromBOOL([eqType canCarryMultiple]);
 			return YES;


### PR DESCRIPTION
… playerBoughtEquipment event

These two changes help with gaining better visibility of equipment prices.

EquipmentInfo.calculatedPrice is the calculated price of the equipment item, if the equipment item utilises the updateEquipmentPrice() condition script function.

Adding the "paid" parameter to the playerBoughtEquipment event gives instant visibility of the actual price paid by the player, taking into account any rebates or adjustments in the purchase.
