### PR TITLE
Adding playerWillBuyNewShip world event

### DIFF
--- a/src/Core/Entities/PlayerEntityContracts.h
+++ b/src/Core/Entities/PlayerEntityContracts.h
@@ -116,7 +116,7 @@ MA 02110-1301, USA.
 
 - (OOCreditsQuantity) priceForShipKey:(NSString *)key;
 - (BOOL) buySelectedShip;
-- (BOOL) buyNamedShip:(NSString *)shipName;
+- (BOOL) replaceShipWithNamedShip:(NSString *)shipName;
 - (void) newShipCommonSetup:(NSString *)shipKey yardInfo:(NSDictionary *)ship_info baseInfo:(NSDictionary *)ship_base_dict; 
 
 @end

--- a/src/Core/Entities/PlayerEntityContracts.m
+++ b/src/Core/Entities/PlayerEntityContracts.m
@@ -1839,7 +1839,7 @@ static NSMutableDictionary *currentShipyard = nil;
 	return YES;
 }
 
-- (BOOL) buyNamedShip:(NSString *)shipKey
+- (BOOL) replaceShipWithNamedShip:(NSString *)shipKey
 {
 
 	NSDictionary *ship_info = [[OOShipRegistry sharedRegistry] shipyardInfoForKey:shipKey];
@@ -1850,8 +1850,8 @@ static NSMutableDictionary *currentShipyard = nil;
 		return NO;
 	}
 
-	// from this point, the player is committed to buying - raise a pre-buy script event
-	[self doScriptEvent:OOJSID("playerWillBuyNewShip") withArgument:shipKey];
+	// from this point, the player is committed to replacing - raise a pre-replace script event
+	[self doScriptEvent:OOJSID("playerWillReplaceShip") withArgument:shipKey];
 
 	[self newShipCommonSetup:shipKey yardInfo:ship_info baseInfo:ship_base_dict];
 

--- a/src/Core/Entities/PlayerEntityContracts.m
+++ b/src/Core/Entities/PlayerEntityContracts.m
@@ -1774,6 +1774,13 @@ static NSMutableDictionary *currentShipyard = nil;
 	if (credits + tradeIn < price * 10)
 		return NO;	// you can't afford it!
 	
+	// from this point, the player is committed to buying - raise a pre-buy script event
+	[self doScriptEvent:OOJSID("playerWillBuyNewShip") 
+		withArguments:[NSArray arrayWithObjects:[shipInfo oo_stringForKey:SHIPYARD_KEY_SHIPDATA_KEY], 
+			[[[self dockedStation] localShipyard] objectAtIndex:selectedRow - GUI_ROW_SHIPYARD_START], 
+			[NSNumber numberWithUnsignedLongLong:price], 
+			[NSNumber numberWithUnsignedLongLong:(tradeIn / 10)], nil]];
+
 	// sell all the commodities carried
 	NSString *good = nil;
 	foreach (good, [shipCommodityData goods])
@@ -1842,7 +1849,10 @@ static NSMutableDictionary *currentShipyard = nil;
 	if (ship_info == nil || ship_base_dict == nil) {
 		return NO;
 	}
-	
+
+	// from this point, the player is committed to buying - raise a pre-buy script event
+	[self doScriptEvent:OOJSID("playerWillBuyNewShip") withArgument:shipKey];
+
 	[self newShipCommonSetup:shipKey yardInfo:ship_info baseInfo:ship_base_dict];
 
 	// perform the transformation

--- a/src/Core/Scripting/OOJSPlayer.m
+++ b/src/Core/Scripting/OOJSPlayer.m
@@ -566,7 +566,7 @@ static JSBool PlayerReplaceShip(JSContext *context, uintN argc, jsval *vp)
 		return NO;
 	}
 	
-	success = [player buyNamedShip:shipKey];
+	success = [player replaceShipWithNamedShip:shipKey];
 	if (argc > 1)
 	{
 		JS_ValueToInt32(context,OOJS_ARGV[1],&personality);
@@ -577,7 +577,9 @@ static JSBool PlayerReplaceShip(JSContext *context, uintN argc, jsval *vp)
 	}
 
 	if (success) 
-	{ // slightly misnamed world event now
+	{ 
+		[player doScriptEvent:OOJSID("playerReplacedShip") withArgument:player andArgument:[NSNumber numberWithInt:0]];
+		// slightly misnamed world event now - to be deprecated
 		[player doScriptEvent:OOJSID("playerBoughtNewShip") withArgument:player andArgument:[NSNumber numberWithInt:0]];
 	}
 

--- a/src/Core/Scripting/OOJSPlayer.m
+++ b/src/Core/Scripting/OOJSPlayer.m
@@ -578,7 +578,7 @@ static JSBool PlayerReplaceShip(JSContext *context, uintN argc, jsval *vp)
 
 	if (success) 
 	{ 
-		[player doScriptEvent:OOJSID("playerReplacedShip") withArgument:player andArgument:[NSNumber numberWithInt:0]];
+		[player doScriptEvent:OOJSID("playerReplacedShip") withArgument:player];
 		// slightly misnamed world event now - to be deprecated
 		[player doScriptEvent:OOJSID("playerBoughtNewShip") withArgument:player andArgument:[NSNumber numberWithInt:0]];
 	}


### PR DESCRIPTION
Gives OXP's an opportunity to do something before the player ship is actually sold/replaced.
Event is in two forms: 

1. When player actually buys a ship from the F3F3 shipyard.
  `this.playerWillBuyNewShip = function(shipKey, shipyard_info, price, tradeIn) {  }`

2. When player ship is changed via the JS method player.replaceShip("shipkey")
  `this.playerWillBuyNewShip = function(shipKey) {  }`