### PR TITLE
Limiting star and nebula textures by galaxy

### DIFF
--- a/src/Core/OOProbabilisticTextureManager.h
+++ b/src/Core/OOProbabilisticTextureManager.h
@@ -40,7 +40,9 @@ SOFTWARE.
 	unsigned				_count;
 	OOTexture				**_textures;
 	float					*_prob;
+	int	                    *_galaxy;
 	float					_probMax;
+	float					*_probMaxGal;
 	RANROTSeed				_seed;
 }
 

--- a/src/Core/OOProbabilisticTextureManager.m
+++ b/src/Core/OOProbabilisticTextureManager.m
@@ -29,6 +29,7 @@ SOFTWARE.
 #import "ResourceManager.h"
 #import "OOTexture.h"
 #import "OOCollectionExtractors.h"
+#import "PlayerEntityScriptMethods.h"
 
 
 @implementation OOProbabilisticTextureManager
@@ -54,12 +55,14 @@ SOFTWARE.
 {
 	BOOL				OK = YES;
 	NSArray				*config = nil;
-	NSUInteger			i, count;
+	NSUInteger			i, count, j;
 	id					entry = nil;
 	NSString			*name = nil;
 	float				probability;
 	OOTexture			*texture = nil;
-	
+	int 				galID = -1;
+	id					object = nil;
+
 	self = [super init];
 	if (self == nil)  OK = NO;
 	
@@ -75,20 +78,34 @@ SOFTWARE.
 		
 		_textures = malloc(sizeof *_textures * count);
 		_prob = malloc(sizeof *_prob * count);
-		
-		if (_textures == NULL || _prob == NULL)  OK = NO;
+		_galaxy = malloc(sizeof *_galaxy * count);
+		_probMaxGal = malloc(sizeof *_probMaxGal * 8);
+
+		if (_textures == NULL || _prob == NULL || _galaxy == NULL)  OK = NO;
 	}
 	
 	if (OK)
 	{
+		for (i = 0; i <= 7; i++) _probMaxGal[i] = 0;
+
 		//  Go through list and load textures.
 		for (i = 0; i != count; ++i)
 		{
 			entry = [config objectAtIndex:i];
+			galID = -1;
 			if ([entry isKindOfClass:[NSDictionary class]])
 			{
 				name = [(NSDictionary *)entry oo_stringForKey:@"texture"];
 				probability = [entry oo_floatForKey:@"probability" defaultValue:1.0f];
+				object = [entry objectForKey:@"galaxy"];
+				if ([object isKindOfClass:[NSString class]])  
+				{
+					galID = [object intValue];
+				}
+				else if (object != nil)
+				{
+					OOLog(@"textures.load", @"***** ERROR: %@ for texture %@ is not a string.", @"galaxy", name);
+				}
 			}
 			else if ([entry isKindOfClass:[NSString class]])
 			{
@@ -110,8 +127,16 @@ SOFTWARE.
 				if (texture != nil)
 				{
 					_textures[_count] = [texture retain];
-					_prob[_count] = probability + _probMax;
-					_probMax += probability;
+					_prob[_count] = probability + (galID >= 0 ? _probMaxGal[galID] : _probMax);
+					_galaxy[_count] = (galID >= 0 ? galID : -1);
+					if (galID >= 0) {
+						_probMaxGal[galID] += probability;
+					}
+					else
+					{
+						for (j = 0; j <= 7; j++) _probMaxGal[j] += probability;
+						_probMax += probability;
+					}
 					++_count;
 				}
 			}
@@ -127,7 +152,7 @@ SOFTWARE.
 		[self release];
 		self = nil;
 	}
-	
+
 	return self;
 }
 
@@ -146,7 +171,9 @@ SOFTWARE.
 	}
 	
 	if (_prob != NULL)  free(_prob);
-	
+	if (_galaxy != NULL)  free(_galaxy);
+	if (_probMaxGal != NULL)  free(_probMaxGal);
+
 	[super dealloc];
 }
 
@@ -161,16 +188,31 @@ SOFTWARE.
 {
 	float					selection;
 	unsigned				i;
-	
+	int						hold = -1;
+	int                		galID = (int)[PLAYER currentGalaxyID];
+
 	selection = randfWithSeed(&_seed);
 	
-	selection *= _probMax;
+	selection *= _probMaxGal[galID];
 	
 	for (i = 0; i != _count; ++i)
 	{
-		if (selection <= _prob[i])  return _textures[i];
+		if (_galaxy[i] == -1 || _galaxy[i] == galID)
+		{
+			// make a note of the index of the first texture that meets the galaxy list criteria (but only if _galaxy is set)
+			if (hold == -1 && _prob[i] > 0 && _galaxy[i] == galID) hold = i;
+			if (selection <= _prob[i])  return _textures[i];
+		}
 	}
 	
+	// first catch point if loop above fails to return a texture
+	// return first texture that meets the galaxy list criteria and has a probability > 0
+	if (hold >= 0) 
+	{
+		OOLog(@"probabilisticTextureManager.internalWarning", @"%s: overrun! Galaxy List requirements not met. Choosing first texture available for galaxy.", __PRETTY_FUNCTION__);
+		return _textures[hold];
+	}
+
 	OOLog(@"probabilisticTextureManager.internalFailure", @"%s: overrun! Choosing last texture.", __PRETTY_FUNCTION__);
 	return _textures[_count - 1];
 }

--- a/src/Core/OOProbabilisticTextureManager.m
+++ b/src/Core/OOProbabilisticTextureManager.m
@@ -79,14 +79,14 @@ SOFTWARE.
 		_textures = malloc(sizeof *_textures * count);
 		_prob = malloc(sizeof *_prob * count);
 		_galaxy = malloc(sizeof *_galaxy * count);
-		_probMaxGal = malloc(sizeof *_probMaxGal * 8);
+		_probMaxGal = malloc(sizeof *_probMaxGal * kOOMaximumGalaxyID);
 
 		if (_textures == NULL || _prob == NULL || _galaxy == NULL)  OK = NO;
 	}
 	
 	if (OK)
 	{
-		for (i = 0; i <= 7; i++) _probMaxGal[i] = 0;
+		for (i = 0; i <= kOOMaximumGalaxyID; i++) _probMaxGal[i] = 0;
 
 		//  Go through list and load textures.
 		for (i = 0; i != count; ++i)
@@ -134,7 +134,7 @@ SOFTWARE.
 					}
 					else
 					{
-						for (j = 0; j <= 7; j++) _probMaxGal[j] += probability;
+						for (j = 0; j <= kOOMaximumGalaxyID; j++) _probMaxGal[j] += probability;
 						_probMax += probability;
 					}
 					++_count;

--- a/src/Core/OOProbabilisticTextureManager.m
+++ b/src/Core/OOProbabilisticTextureManager.m
@@ -79,7 +79,7 @@ SOFTWARE.
 		_textures = malloc(sizeof *_textures * count);
 		_prob = malloc(sizeof *_prob * count);
 		_galaxy = malloc(sizeof *_galaxy * count);
-		_probMaxGal = malloc(sizeof *_probMaxGal * kOOMaximumGalaxyID);
+		_probMaxGal = malloc(sizeof *_probMaxGal * (kOOMaximumGalaxyID + 1));
 
 		if (_textures == NULL || _prob == NULL || _galaxy == NULL)  OK = NO;
 	}

--- a/src/Core/ResourceManager.h
+++ b/src/Core/ResourceManager.h
@@ -82,8 +82,9 @@ typedef enum
 
 
 + (void)handleEquipmentListMerging: (NSMutableArray *)arrayToProcess forLookupIndex:(unsigned)lookupIndex;
++ (void)handleStarNebulaListMerging: (NSMutableArray *)arrayToProcess;
 
-+ (NSString *)errors;			// Errors which occured during path scanning - essentially a list of OXPs whose requires.plist is bad.
++ (NSString *)errors;			// Errors which occurred during path scanning - essentially a list of OXPs whose requires.plist is bad.
 
 + (NSString *) pathForFileNamed:(NSString *)fileName inFolder:(NSString *)folderName;
 + (NSString *) pathForFileNamed:(NSString *)fileName inFolder:(NSString *)folderName cache:(BOOL)useCache;


### PR DESCRIPTION
This adds the ability to limit star and nebula textures to particular galaxies, providing the opportunity to make galaxies more visually unique. 

At the same time, in order to make the merging of star and nebula textures more logical and consistent, they are now being merged on the "texture" key. Therefore, if an OXP overrides the "oolite-nebula-1.png" definition in a "nebulatextures.plist" file (for instance, adding a galaxy or changing the probability), they can be confident this change has been applied. To allow for the same texture to appear in multiple galaxies, an optional "key" property can be added to the dictionary, which will take the place of the "texture" property when merging the arrays.

To demonstrate this, use the following in place of the current nebulatextures.plist, which will allocate one nebula image per galaxy.

```
(
	{
		texture = "oolite-nebula-1.png";
		probability = 1.0;
		galaxy = 0;
	},
	{
		texture = "oolite-nebula-2.png";
		probability = 1.0;
		galaxy = 1;
	},
	{
		texture = "oolite-nebula-3.png";
		probability = 1.0;
		galaxy = 2;
	},
	{
		texture = "oolite-nebula-4.png";
		probability = 1.0;
		galaxy = 3;
	},
	{
		texture = "oolite-nebula-1.png";
		key = "nebula1-gal4";
		probability = 1.0;
		galaxy = 4;
	},
	{
		texture = "oolite-nebula-2.png";
		key = "nebula2-gal5";
		probability = 1.0;
		galaxy = 5;
	},
	{
		texture = "oolite-nebula-3.png";
		key = "nebula3-gal6";
		probability = 1.0;
		galaxy = 6;
	},
	{
		texture = "oolite-nebula-4.png";
		key = "nebula4-gal7";
		probability = 1.0;
		galaxy = 7;
	}
)

```
If no "galaxy" property is set, existing behaviour should be unchanged.

Outstanding: I really need someone to confirm I've done the alloc/dealloc correctly. 
