### PR TITLE
Adding support for equipment-overrides.plist

### DIFF
--- a/src/Core/ResourceManager.h
+++ b/src/Core/ResourceManager.h
@@ -82,6 +82,7 @@ typedef enum
 
 
 + (void)handleEquipmentListMerging: (NSMutableArray *)arrayToProcess forLookupIndex:(unsigned)lookupIndex;
++ (void)handleEquipmentOverrides: (NSMutableArray *)arrayToProcess;
 + (void)handleStarNebulaListMerging: (NSMutableArray *)arrayToProcess;
 
 + (NSString *)errors;			// Errors which occurred during path scanning - essentially a list of OXPs whose requires.plist is bad.


### PR DESCRIPTION
Adds the ability to process equipment-overrides.plist files, which allows OXP authors to more easily update existing equipment items without needing to copy the entire equipment.plist entry in order to do so. Also, it reduces the potential conflicts where two OXP's want to update the same equipment item. It doesn't solve the issue of two OXP's wanting to update the same properties of said equipment item - the last overrides file will still be the winner here, which is the same for the shipdata-overrides file.

The format of the equipment-overrides.plist is slightly different to the equipment.plist file by necessity. A sample file is shown:
```
{
	"EQ_WEAPON_PULSE_LASER" = {
		techlevel = 7;
		price = 50000;
		short_description = "Laser Pointer";
		long_description = "A simple, all purpose (but weak) laser. Only useful for irritating pirates.";
		available_to_all = YES;
		weapon_info = {
			color = "whiteColor";
		};
	};
}
```
Notes: I'm not sure I like where I've put the interface to the routine - it feels kind of tacked-on rather than part of a deliberate design. But on the flip side, the current location means we don't have to make the equipment array mutable (again), do the overrides, and make it immutable (yet again), which feels slow and inefficient. Open to suggestions on this one.
