### PR TITLE
Adds weaponInfo to EquipmentInfo script object

### DIFF
--- a/src/Core/OOEquipmentType.h
+++ b/src/Core/OOEquipmentType.h
@@ -142,6 +142,7 @@ SOFTWARE.
 // weapon properties
 - (BOOL) isTurretLaser;
 - (BOOL) isMiningLaser;
+- (NSDictionary *) weaponInfo;
 - (GLfloat) weaponRange;
 - (GLfloat) weaponEnergyUse;
 - (GLfloat) weaponDamage;

--- a/src/Core/OOEquipmentType.m
+++ b/src/Core/OOEquipmentType.m
@@ -630,6 +630,12 @@ static NSDictionary		*sMissilesRegistry = nil;
 }
 
 
+- (NSDictionary *) weaponInfo
+{
+	return _weaponInfo;
+}
+
+
 - (GLfloat) weaponRange
 {
 	return [_weaponInfo oo_floatForKey:@"range" defaultValue:12500.0];

--- a/src/Core/Scripting/OOJSEquipmentInfo.m
+++ b/src/Core/Scripting/OOJSEquipmentInfo.m
@@ -77,7 +77,8 @@ enum
 	kEquipmentInfo_requiresNonFullFuel,
 	kEquipmentInfo_scriptInfo,					// arbitrary data for scripts, dictionary, read-only
 	kEquipmentInfo_scriptName,
-	kEquipmentInfo_techLevel
+	kEquipmentInfo_techLevel,
+	kEquipmentInfo_weaponInfo
 };
 
 
@@ -117,6 +118,7 @@ static JSPropertySpec sEquipmentInfoProperties[] =
 	{ "scriptInfo",						kEquipmentInfo_scriptInfo,					OOJS_PROP_READONLY_CB },
 	{ "scriptName",						kEquipmentInfo_scriptName,					OOJS_PROP_READONLY_CB },
 	{ "techLevel",						kEquipmentInfo_techLevel,					OOJS_PROP_READONLY_CB },
+	{ "weaponInfo",						kEquipmentInfo_weaponInfo,					OOJS_PROP_READONLY_CB },
 	{ 0 }
 };
 
@@ -388,6 +390,11 @@ static JSBool EquipmentInfoGetProperty(JSContext *context, JSObject *this, jsid 
 		case kEquipmentInfo_scriptName:
 			result = [eqType scriptName];
 			if (result == nil) result = @"";
+			break;
+			
+		case kEquipmentInfo_weaponInfo:
+			result = [eqType weaponInfo];
+			if (result == nil)  result = [NSDictionary dictionary];	// empty rather than null
 			break;
 			
 		default:


### PR DESCRIPTION
weapon_info was included in equipment.plist in v1.81, but there's no way for scripts to recover that information, so I added it to EquipmentInfo scripting object as 'weaponInfo', a dictionary with the weapon_info fields from equipment.plist (used scripInfo as template)

I have been using this mod for 9 days (Towbar v0.105 's Laser Reductor uses it to set the amount of energy to give back when a derelicts is hit), the glitches were all on the script side.

There are a few other OXPs that use weapon_info, but they are expecting a dictionary with name "weapon_info"... the property I added is camel case, like all other scripting object's properties, so those OXPs will have to be updated to use the new property