### PR TITLE
Doesn't block an equipment installation if an incompatible equipment had been installed but has already been removed

### DIFF
--- a/Resources/Scripts/oolite-equipment-control.js
+++ b/Resources/Scripts/oolite-equipment-control.js
@@ -159,9 +159,11 @@ this.equipmentAdded = function(equip)
 	var eq_dict = this.$equipmentEnabled;
 	var eqInfo;
 	for (var eqKey in eq_dict) {
-		eqInfo = EquipmentInfo.infoForKey(eqKey);
-		if (eqInfo && eqInfo.incompatibleEquipment && eqInfo.incompatibleEquipment.indexOf(equip) >= 0) {
-			player.ship.removeEquipment(eqKey);
+		if (this.$equipmentEnabled[eqKey]) {
+			eqInfo = EquipmentInfo.infoForKey(eqKey);
+			if (eqInfo && eqInfo.incompatibleEquipment && eqInfo.incompatibleEquipment.indexOf(equip) >= 0) {
+				player.ship.removeEquipment(eqKey);
+			}
 		}
 	}
 	this.$equipmentEnabled[equip] = 1;

--- a/Resources/Scripts/oolite-equipment-control.js
+++ b/Resources/Scripts/oolite-equipment-control.js
@@ -156,9 +156,11 @@ this.equipmentAdded = function(equip)
 	var eq_dict = this.$equipmentEnabled;
 	var eqInfo;
 	for (var eqKey in eq_dict) {
-		eqInfo = EquipmentInfo.infoForKey(eqKey);
-		if (eqInfo && eqInfo.incompatibleEquipment && eqInfo.incompatibleEquipment.indexOf(equip) >= 0) {
-			player.ship.removeEquipment(eqKey);
+		if (this.$equipmentEnabled[eqKey]) {
+			eqInfo = EquipmentInfo.infoForKey(eqKey);
+			if (eqInfo && eqInfo.incompatibleEquipment && eqInfo.incompatibleEquipment.indexOf(equip) >= 0) {
+				player.ship.removeEquipment(eqKey);
+			}
 		}
 	}
 	this.$equipmentEnabled[equip] = 1;


### PR DESCRIPTION
An equipmentKey isn't removed from oolite-equipment-control's this.$equipmentEnabled dictionary keys when an equipment is removed, the value for that key is changed to 0 if the equipment was removed (and to 1 if it's installed or re-installed).

So not all keys in this.$equipmentEnabled represent equipments that are installed in the ship and it's necessary to check the value for that key in the dictionary to make sure the equipment is installed and only after that look for the equipments incompatible with it.

Without this correction, if an equipment was installed it would block the installation of equipments incompatible with it even after it was uninstalled.

To reproduce, install Smivs Battle Damage OXP and remove the equipment EQ_HULL_REPAIR from a ship and then try to award it back (it's incompatible with self)