### PR TITLE
Fix an error reported by gcc about format-security

### DIFF
--- a/src/SDL/MyOpenGLView.m
+++ b/src/SDL/MyOpenGLView.m
@@ -324,7 +324,7 @@ MA 02110-1301, USA.
 	}
 	
 	int testAttrib = -1;
-	OOLog(@"display.initGL", @"Achieved color / depth buffer sizes (bits):");
+	OOLog(@"display.initGL", @"%@", @"Achieved color / depth buffer sizes (bits):");
 	SDL_GL_GetAttribute(SDL_GL_RED_SIZE, &testAttrib);
 	OOLog(@"display.initGL", @"Red: %d", testAttrib);
 	SDL_GL_GetAttribute(SDL_GL_GREEN_SIZE, &testAttrib);


### PR DESCRIPTION
On Fedora 32, gcc 10.2.1 reports an error:
```bash
 Compiling file src/SDL/MyOpenGLView.m ...
src/SDL/MyOpenGLView.m: In function ‘-[MyOpenGLView init]’:
src/SDL/MyOpenGLView.m:327:2: error: format not a string literal and no format arguments [-Werror=format-security]
  327 |  OOLog(@"display.initGL", @"Achieved color / depth buffer sizes (bits):");
      |  ^
cc1obj: some warnings being treated as errors
```
This PR fixes the issue on my system.