### PR TITLE
Unlock Game Load/Save screen when paused while docked.

### DIFF
--- a/src/Core/Entities/PlayerEntityControls.m
+++ b/src/Core/Entities/PlayerEntityControls.m
@@ -4288,7 +4288,30 @@ static BOOL autopilot_pause;
 			pause_pressed = NO;
 		}
 		
-		if ([gameController isGamePaused]) return;
+		if ([gameController isGamePaused])
+		{
+			if (gui_screen == GUI_SCREEN_OPTIONS || gui_screen == GUI_SCREEN_GAMEOPTIONS || gui_screen == GUI_SCREEN_STICKMAPPER || gui_screen == GUI_SCREEN_STICKPROFILE || gui_screen == GUI_SCREEN_KEYBOARD)
+			{
+				if ([UNIVERSE pauseMessageVisible]) [[UNIVERSE messageGUI] leaveLastLine];
+				else [[UNIVERSE messageGUI] clear];
+				NSTimeInterval	time_this_frame = [NSDate timeIntervalSinceReferenceDate];
+				OOTimeDelta		time_delta;
+				if (![[GameController sharedController] isGamePaused])
+				{
+					time_delta = time_this_frame - time_last_frame;
+					time_last_frame = time_this_frame;
+					time_delta = OOClamp_0_max_d(time_delta, MINIMUM_GAME_TICK);
+				}
+				else
+				{
+					time_delta = 0.0;
+				}
+				
+				script_time += time_delta;
+				[self pollGuiArrowKeyControls:time_delta];
+			}
+			return;
+		}
 		
 		if(pollControls)
 		{


### PR DESCRIPTION
Currently if you pause when in Game Load/Save screen and while docked the controls are locked and no options can be altered. On the other hand if you pause while in flight and activate the Game Load/Save screen then options are available for configuration.
This change is to ensure Game Load/Save screen consistent behavior when paused while docked and when paused while in flight. 