### PR TITLE
Script assing to weapon mount fix

### DIFF
--- a/src/Core/Scripting/OOJSShip.m
+++ b/src/Core/Scripting/OOJSShip.m
@@ -1862,7 +1862,11 @@ static JSBool ShipSetProperty(JSContext *context, JSObject *this, jsid propID, J
 					facing = [entity currentWeaponFacing];
 					break;
 			}
-			[entity setWeaponMount:facing toWeapon:sValue];
+			if (entity == PLAYER) {
+				[entity setWeaponMount:facing toWeapon:sValue inContext:@"scripted"];
+			} else {
+				[entity setWeaponMount:facing toWeapon:sValue];
+			}
 			return YES;
 
 		case kShip_maxEscorts:


### PR DESCRIPTION
This PR fixes a bug when a weapon is assigned to a weaponMount by script: if the weapon has a condition_script with allowAwardEquipment defined, it is being called with context "purchase" instead of "scripted". (ship.awardEquipment, which is used to award everything but weapons, already sets the context to "scripted")

That breaks Ship Storage Helper OXP when it tries to restore a ship that has a laser with purchase restrictions, such as Weapon Laws OXP creates.

To replicate the bug, install Weapon Laws OXP and try to assign EQ_WEAPON_MILITARY_LASER to a ship at Lave with the Debug Console. The Military laser will not be available in the Ship Outfitting, due to the condition_scripts' allowAwardEquipment allowing purchase of it only in Anarchies, Feudal States and Multi-government systems, but it allows the award in context scripted, npc, etc., so it should be possible for a script to assign it.