### PR TITLE
Derelict desctruction is not a kill

### DIFF
--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -6788,6 +6788,10 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 		NSString *bonusMessage = OOExpandKey(@"bounty-awarded", score, credits);
 		[UNIVERSE addDelayedMessage:bonusMessage forCount:6 afterDelay:0.15];
 	}
+
+	if ([other isUnpiloted]) {
+		killAward = NO;
+	}
 	
 	if (killAward)
 	{

--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -6789,7 +6789,7 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 		[UNIVERSE addDelayedMessage:bonusMessage forCount:6 afterDelay:0.15];
 	}
 
-	if ([other isUnpiloted]) {
+	if ([other isHulk]) {
 		killAward = NO;
 	}
 	

--- a/src/Core/Entities/ShipEntity.m
+++ b/src/Core/Entities/ShipEntity.m
@@ -13296,7 +13296,12 @@ Vector positionOffsetForShipInRotationToAlignment(ShipEntity* ship, Quaternion q
 		}
 		if ((energy < maxEnergy *0.125 || (energy < 64 && energy < amount*2)) && [self hasEscapePod] && (ranrot_rand() & 3) == 0)  // 25% chance he gets to an escape pod
 		{
-			[self abandonShip];
+			if ([self abandonShip]) {
+				if (hunter == PLAYER) {
+					NSUInteger kills = [hunter score];
+					[hunter setScore:(kills+1)];
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes a scenario where the player can increase his rank by searching derelicts left from NPC's conflicts and destroying them.

It increases the player's score when a NPC chooses (as implemented at the core game level, at ShipEntity's takeEnergyDamage) to abandon ship when its energy is too low after a hit from a player's attack, which has the added benefit of allowing players with moral restrictions to killing to improve their ranking (which is necessary for progress in many of the core game careers).