### PR TITLE
Adding "setShipInfoForKey"

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,15 +47,19 @@ For end-user documentation, see [oolite.org](http://www.oolite.org/) and
 - **tools**:  Various tools for preparing files, builds, releases etc.
 
 ## Building
-On Mac OS X, you will need the latest version of Xcode from the App Store.
+### Mac OS X
+You will need the latest version of Xcode from the App Store.
 Then double click on the Xcode project in the Finder, select one of the Oolite
 targets from the Scheme pop-up, and hit Build and Run (the play button in the
 toolbar).
 
-For Windows, see the Oolite wiki:
+### Windows
+See the Oolite wiki:
 http://wiki.alioth.net/index.php/Running_Oolite-Windows
 
-On Linux, if you have the Debian package tools (installed by default with
+### Linux
+
+If you have the Debian package tools (installed by default with
 Debian and Ubuntu), use dpkg-buildpackage.
 
 On Linux, BSD and other Unix platforms without dpkg tools, you will need to
@@ -66,7 +70,8 @@ distros, GNUstep and SDL development libraries come prepackaged - just
 apt-get/yum install the relevant files. You may also need to install Mozilla
 Spidermonkey (libmozjs). On others you may need to build them from source. In
 particular, you need the SDL_Mixer library, which doesn't always come with the
-base SDL development kit.  
+base SDL development kit.
+
 Then just type `make`, or, if you're using GNU make,
 `make -f Makefile`. On some systems, such as Gentoo, you may need to run
 `make -f Makefile OBJCFLAGS=-fobjc-exceptions`.  
@@ -77,8 +82,8 @@ Also remember to first fetch the various submodules, see [Git](#Git).
 
 ## Running
 On OS X, you can run from Xcode by clicking on the appropriate icon
-(or choosing 'Run' from the 'Product' menu).
-On Linux/BSD/Unix, in a terminal, type `openapp oolite`
+(or choosing 'Run' from the 'Product' menu).  
+On Linux/BSD/Unix, in a terminal, type `openapp oolite`, or if you compiled it yourself you can run it with `./oolite.app/oolite`.
 
 ## Git
 The Oolite source is available from github.

--- a/README.md
+++ b/README.md
@@ -66,9 +66,14 @@ distros, GNUstep and SDL development libraries come prepackaged - just
 apt-get/yum install the relevant files. You may also need to install Mozilla
 Spidermonkey (libmozjs). On others you may need to build them from source. In
 particular, you need the SDL_Mixer library, which doesn't always come with the
-base SDL development kit. Then just type `make`, or, if you're using GNU make,
+base SDL development kit.  
+Then just type `make`, or, if you're using GNU make,
 `make -f Makefile`. On some systems, such as Gentoo, you may need to run
-`make -f Makefile OBJCFLAGS=-fobjc-exceptions`.
+`make -f Makefile OBJCFLAGS=-fobjc-exceptions`.  
+If you get errors like `make[1]: *** No rule to make target '/objc.make'.  Stop.` it might help if you run `source /usr/share/GNUstep/Makefiles/GNUstep.sh` (the exact path to `GNUstep.sh` might differ).  
+If you have problems with missing textures you can try to delete `deps/Linux-deps/include/png.h` and `deps/Linux-deps/include/pngconf.h` before compiling.
+
+Also remember to first fetch the various submodules, see [Git](#Git).
 
 ## Running
 On OS X, you can run from Xcode by clicking on the appropriate icon

--- a/src/Core/OOShipRegistry.h
+++ b/src/Core/OOShipRegistry.h
@@ -47,6 +47,7 @@ SOFTWARE.
 + (void) reload;
 
 - (NSDictionary *) shipInfoForKey:(NSString *)key;
+- (void) setShipInfoForKey:(NSString *)key with:(NSDictionary *)newShipData;
 - (NSDictionary *) effectInfoForKey:(NSString *)key;
 - (NSDictionary *) shipyardInfoForKey:(NSString *)key;
 - (OOProbabilitySet *) probabilitySetForRole:(NSString *)role;

--- a/src/Core/OOShipRegistry.m
+++ b/src/Core/OOShipRegistry.m
@@ -209,6 +209,12 @@ static NSString * const	kVisualEffectDataCacheKey = @"visual effect data";
 	return [_shipData objectForKey:key];
 }
 
+- (void) setShipInfoForKey:(NSString *)key with:(NSDictionary *)newShipData
+{
+	NSMutableDictionary *mutableDict = [_shipData mutableCopy];
+	[mutableDict setObject:OODeepCopy(newShipData) forKey:key];
+	_shipData = [mutableDict mutableCopy];
+}
 
 - (NSDictionary *) effectInfoForKey:(NSString *)key
 {

--- a/src/Core/OOShipRegistry.m
+++ b/src/Core/OOShipRegistry.m
@@ -211,7 +211,7 @@ static NSString * const	kVisualEffectDataCacheKey = @"visual effect data";
 
 - (void) setShipInfoForKey:(NSString *)key with:(NSDictionary *)newShipData
 {
-	NSMutableDictionary *mutableDict = [_shipData mutableCopy];
+	NSMutableDictionary *mutableDict = [NSMutableDictionary dictionaryWithDictionary:_shipData];
 	[mutableDict setObject:OODeepCopy(newShipData) forKey:key];
 	_shipData = [mutableDict mutableCopy];
 }

--- a/src/Core/OOShipRegistry.m
+++ b/src/Core/OOShipRegistry.m
@@ -213,7 +213,8 @@ static NSString * const	kVisualEffectDataCacheKey = @"visual effect data";
 {
 	NSMutableDictionary *mutableDict = [NSMutableDictionary dictionaryWithDictionary:_shipData];
 	[mutableDict setObject:OODeepCopy(newShipData) forKey:key];
-	_shipData = [mutableDict mutableCopy];
+	DESTROY(_shipData);
+	_shipData = [[NSDictionary dictionaryWithDictionary:mutableDict] retain];
 }
 
 - (NSDictionary *) effectInfoForKey:(NSString *)key

--- a/src/Core/Scripting/OOJSShip.m
+++ b/src/Core/Scripting/OOJSShip.m
@@ -151,6 +151,7 @@ static JSBool ShipStaticKeys(JSContext *context, uintN argc, jsval *vp);
 static JSBool ShipStaticRoles(JSContext *context, uintN argc, jsval *vp);
 static JSBool ShipStaticRoleIsInCategory(JSContext *context, uintN argc, jsval *vp);
 static JSBool ShipStaticShipDataForKey(JSContext *context, uintN argc, jsval *vp);
+static JSBool ShipStaticSetShipDataForKey(JSContext *context, uintN argc, jsval *vp);
 
 static JSClass sShipClass =
 {
@@ -575,6 +576,7 @@ static JSFunctionSpec sShipStaticMethods[] =
 	{ "roleIsInCategory",	ShipStaticRoleIsInCategory,		2 },
 	{ "roles",				ShipStaticRoles,				0 },
 	{ "shipDataForKey",		ShipStaticShipDataForKey,		1 },
+	{ "setShipDataForKey",  ShipStaticSetShipDataForKey,    2 },
 	{ 0 }
 };
 
@@ -4353,6 +4355,26 @@ static JSBool ShipStaticShipDataForKey(JSContext *context, uintN argc, jsval *vp
 	else
 	{
 		OOJSReportBadArguments(context, @"Ship", @"shipDataForKey", MIN(argc, 1U), OOJS_ARGV, nil, @"ship role");
+		return NO;
+	}
+	OOJS_NATIVE_EXIT
+}
+
+static JSBool ShipStaticSetShipDataForKey(JSContext *context, uintN argc, jsval *vp)
+{
+	OOJS_NATIVE_ENTER(context);
+	OOShipRegistry                  *registry = [OOShipRegistry sharedRegistry];
+
+	if (argc >= 2)
+	{
+		NSString *key = OOStringFromJSValue(context, OOJS_ARGV[0]);
+		NSDictionary *newShipData = OOJSNativeObjectFromJSObject(context, JSVAL_TO_OBJECT(OOJS_ARGV[1]));
+		[registry setShipInfoForKey:key with:newShipData];
+		OOJS_RETURN_BOOL(YES);
+	}
+	else
+	{
+		OOJSReportBadArguments(context, @"Ship", @"setShipInfoForKey", MIN(argc, 2U), OOJS_ARGV, nil, @"ship role");
 		return NO;
 	}
 	OOJS_NATIVE_EXIT

--- a/src/Core/Scripting/OOJSShip.m
+++ b/src/Core/Scripting/OOJSShip.m
@@ -4354,7 +4354,7 @@ static JSBool ShipStaticShipDataForKey(JSContext *context, uintN argc, jsval *vp
 	}
 	else
 	{
-		OOJSReportBadArguments(context, @"Ship", @"shipDataForKey", MIN(argc, 1U), OOJS_ARGV, nil, @"ship role");
+		OOJSReportBadArguments(context, @"Ship", @"shipDataForKey", MIN(argc, 1U), OOJS_ARGV, nil, @"key");
 		return NO;
 	}
 	OOJS_NATIVE_EXIT
@@ -4374,7 +4374,7 @@ static JSBool ShipStaticSetShipDataForKey(JSContext *context, uintN argc, jsval 
 	}
 	else
 	{
-		OOJSReportBadArguments(context, @"Ship", @"setShipInfoForKey", MIN(argc, 2U), OOJS_ARGV, nil, @"ship role");
+		OOJSReportBadArguments(context, @"Ship", @"setShipInfoForKey", MIN(argc, 2U), OOJS_ARGV, nil, @"key shipdata");
 		return NO;
 	}
 	OOJS_NATIVE_EXIT


### PR DESCRIPTION
This should add the javascript function `function setShipDataForKey(datakey : String, newShipData : Object)` that sets the shipdata for a specific datakey. This will allow OXPs to fiddle with the properties of all ships directly. For example, an OXP that sets the `shipdata.max_yaw` value to 60% that of `shipdata.max_pitch`, emulating a similar mechanic in Elite: Dangerous, where the maximum yaw is smaller than the pitch. Or an OXP that re-evaluates the prices of ships in the shipyard.

I also added some helpful tips for compiling on Linux.

This is a draft because I am not sure, if I introduced memory leaks, as I don't know Objective-C very well.