### PR TITLE
Fix for correct context when adding weapons to player ship

### DIFF
--- a/src/Core/Scripting/OOJSShip.m
+++ b/src/Core/Scripting/OOJSShip.m
@@ -1864,7 +1864,15 @@ static JSBool ShipSetProperty(JSContext *context, JSObject *this, jsid propID, J
 					facing = [entity currentWeaponFacing];
 					break;
 			}
-			[entity setWeaponMount:facing toWeapon:sValue];
+			if ([entity isPlayer])
+			{
+				PlayerEntity *pent = (PlayerEntity*)entity;
+				[pent setWeaponMount:facing toWeapon:sValue inContext:@"scripted"];
+			}
+			else 
+			{
+				[entity setWeaponMount:facing toWeapon:sValue];
+			}
 			return YES;
 
 		case kShip_maxEscorts:


### PR DESCRIPTION
Adding a weapon to the player ship via a script passes a "purchase" context through to the "allowAwardEquipment" condition script call, even when the weapon is added via script. This code change enforces the "scripted" context when a weapon change is made by script.