### PR TITLE
Added setVolume to JavaScript interface

### DIFF
--- a/src/Core/OOMusicController.h
+++ b/src/Core/OOMusicController.h
@@ -69,6 +69,8 @@ typedef enum
 - (void) setMissionMusic:(NSString *)missionMusicName;
 - (void) playMissionMusic;
 
+- (void) setMusicGain:(float)gain;
+
 - (void) justStop;
 - (void) stop;
 - (void) stopMusicNamed:(NSString *)name;	// Stop only if name == playingMusic

--- a/src/Core/OOMusicController.m
+++ b/src/Core/OOMusicController.m
@@ -166,6 +166,12 @@ enum
 }
 
 
+- (void) setMusicGain:(float)gain
+{
+	[_current setMusicGain:OOClamp_0_1_f(gain)];;
+}
+
+
 // Stop without switching iTunes to in-flight music.
 - (void) justStop
 {

--- a/src/Core/Scripting/OOJSSound.m
+++ b/src/Core/Scripting/OOJSSound.m
@@ -42,6 +42,7 @@ static JSBool SoundGetProperty(JSContext *context, JSObject *this, jsid propID, 
 static JSBool SoundStaticLoad(JSContext *context, uintN argc, jsval *vp);
 static JSBool SoundStaticMusicSoundSource(JSContext *context, uintN argc, jsval *vp);
 static JSBool SoundStaticPlayMusic(JSContext *context, uintN argc, jsval *vp);
+static JSBool SoundStaticSetVolume(JSContext *context, uintN argc, jsval *vp);
 static JSBool SoundStaticStopMusic(JSContext *context, uintN argc, jsval *vp);
 
 
@@ -91,6 +92,7 @@ static JSFunctionSpec sSoundStaticMethods[] =
 	{ "load",					SoundStaticLoad,			1, },
 	{ "musicSoundSource",		SoundStaticMusicSoundSource,0, },
 	{ "playMusic",				SoundStaticPlayMusic,		1, },
+	{ "setVolume",				SoundStaticSetVolume,		1, },
 	{ "stopMusic",				SoundStaticStopMusic,		0, },
 	{ 0 }
 };
@@ -249,6 +251,37 @@ static JSBool SoundStaticPlayMusic(JSContext *context, uintN argc, jsval *vp)
 	
 	OOJS_RETURN_VOID;
 	
+	OOJS_NATIVE_EXIT
+}
+
+
+// setVolume(gain : float)
+static JSBool SoundStaticSetVolume(JSContext *context, uintN argc, jsval *vp)
+{
+	OOJS_NATIVE_ENTER(context)
+
+	double gain = OO_DEFAULT_SOUNDSOURCE_GAIN;
+
+	if (argc > 0)
+	{
+		if (!OOJSArgumentListGetNumber(context, @"Sound", @"setVolume", 2, OOJS_ARGV, &gain, NULL))
+		{
+			OOJSReportBadArguments(context, @"Sound", @"setVolume", 1, OOJS_ARGV, nil, @"float");
+			return NO;
+		}
+	}
+	else
+	{
+		OOJSReportBadArguments(context, @"Sound", @"setVolume", MIN(argc, 1U), OOJS_ARGV, nil, @"float");
+		return NO;
+	}
+
+	OOJS_BEGIN_FULL_NATIVE(context)
+	[[OOMusicController sharedController] setMusicGain:(float)gain];
+	OOJS_END_FULL_NATIVE
+
+	OOJS_RETURN_VOID;
+
 	OOJS_NATIVE_EXIT
 }
 


### PR DESCRIPTION
[Relevant post on the forum](http://www.aegidian.org/bb/viewtopic.php?p=280941#p280941).

Here is a short exemplary OXP that makes use of this new function:
```javascript
"use strict";

this._volume = 1.0;
this._addition = -0.05;
this._timer = null;

this._changeVolume = function() {
	this._volume += this._addition;

	if(this._volume >= 1.0)
		this._addition = -0.05;
	if(this._volume <= 0.0)
		this._addition = 0.05;
	
	this._volume = Math.min(Math.max(this._volume, 0.0), 1.0);
	
	Sound.setVolume(this._volume); // sets the volume of the currently playing music
}


this.shipLaunchedFromStation = function(stationLaunchedFrom)
{
	Sound.playMusic("yourmusicfile.ogg", false, 1.0);
	this._timer = new Timer(this, this._changeVolume.bind(this), 5, 0.1);
}
```
It starts a song when undocking, and then fades in and fades out again.