### PR TITLE
Update oolite.desktop

### DIFF
--- a/installers/FreeDesktop/oolite.desktop
+++ b/installers/FreeDesktop/oolite.desktop
@@ -6,3 +6,4 @@ Icon=oolite-icon
 Terminal=false
 Type=Application
 Categories=Game;Simulation;
+StartupWMClass=oolite


### PR DESCRIPTION
This desktop file added an icon to the desktop manager. But as soon as the application was started it was not recognized as this icon being active, and another icon would get displayed for the active window. With this patch the desktop manager can correctly identify the window and just mark the existing icon as being active.