### PR TITLE
Added option for startUp script time limit

### DIFF
--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -2241,7 +2241,7 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 	[self setLastAegisLock:[UNIVERSE planet]];
 		
 	JSContext *context = OOJSAcquireContext();
-	[self doWorldScriptEvent:OOJSID("startUp") inContext:context withArguments:NULL count:0 timeLimit:kOOJSLongTimeLimit];
+	[self doWorldScriptEvent:OOJSID("startUp") inContext:context withArguments:NULL count:0 timeLimit:MAX(0.0, [[NSUserDefaults standardUserDefaults] oo_floatForKey:@"start-script-limit-value" defaultValue:kOOJSLongTimeLimit])];
 	OOJSRelinquishContext(context);
 }
 


### PR DESCRIPTION
Fixes issue #400, by allowing to customize the time limit of startUp scripts in the `oolite.plist` config file. Defaults to previous value of 5 seconds.