### PR TITLE
Adjusts descriptions on fast activation pages for better clarity

### DIFF
--- a/Resources/Config/descriptions.plist
+++ b/Resources/Config/descriptions.plist
@@ -544,9 +544,9 @@
 	"equipment-primed-none-available"	= "No equipment can be primed.";
 	
 	"oolite-primablemanager-notify-setup" = "Adjust settings on interface screen if necessary";
-	"oolite-primablemanager-notify-assign" = "Assigned [oolite-primable-equipment] to [oolite-primable-slot] fast activation control";
-	"oolite-primablemanager-slot-defensive" = "defensive";
-	"oolite-primablemanager-slot-offensive" = "offensive";
+	"oolite-primablemanager-notify-assign" = "Assigned [oolite-primable-equipment] to [oolite-primable-slot] fast activation control key";
+	"oolite-primablemanager-slot-defensive" = "key [oolite_key_fastactivate_equipment_a]";
+	"oolite-primablemanager-slot-offensive" = "key [oolite_key_fastactivate_equipment_b]";
 
 
 	"mfd-N-selected"				= "Multi-function display [mfdID] selected.";
@@ -1272,8 +1272,8 @@
 	"oolite-keydesc-key_prime_previous_equipment"	= "Prime previous equipment";
 	"oolite-keydesc-key_activate_equipment"		= "Activate equipment";
 	"oolite-keydesc-key_mode_equipment"			= "Set equipment mode";
-	"oolite-keydesc-key_fastactivate_equipment_a" = "Fast-activate equipment A";
-	"oolite-keydesc-key_fastactivate_equipment_b" = "Fast-activate equipment B";
+	"oolite-keydesc-key_fastactivate_equipment_a" = "Fast-activate first equipment item";
+	"oolite-keydesc-key_fastactivate_equipment_b" = "Fast-activate second equipment item";
 
 	"oolite-keydesc-key_target_incoming_missile"	= "Target incoming missile";
 	"oolite-keydesc-key_target_missile"			= "Arm missile/bomb";

--- a/Resources/Config/missiontext.plist
+++ b/Resources/Config/missiontext.plist
@@ -177,18 +177,18 @@
 	// primable equipment management
 	"oolite-primablemanager-interface-title" = "Manage primable equipment";
 	"oolite-primablemanager-interface-category" = "[interfaces-category-ship-systems]";
-	"oolite-primablemanager-interface-summary" = "Assign primable equipment fitted to your ship to the two fast activation controls, for easy access in emergencies.";
+	"oolite-primablemanager-interface-summary" = "Assign primable equipment fitted to your ship to the two fast activation controls keys, for easy access in emergencies.";
 	"oolite-primablemanager-next" = "Next page";
 	"oolite-primablemanager-previous" = "Previous page";
 
-	"oolite-primablemanager-page1-title" = "Set first fast activation (defensive)";
-	"oolite-primablemanager-page2-title" = "Set second fast activation (offensive)";
-	"oolite-primablemanager-setup-text" = "Select the equipment to bind to this fast activation control.";
+	"oolite-primablemanager-page1-title" = "Set first 'fast activation key' ([oolite-primablemanager-slot-defensive])";
+	"oolite-primablemanager-page2-title" = "Set second 'fast activation key' ([oolite-primablemanager-slot-offensive])";
+	"oolite-primablemanager-setup-text" = "Select the equipment to bind to this fast activation control key.";
 	"oolite-primablemanager-page3-title" = "Fast activation settings saved";
 	"oolite-primablemanager-select-none" = "Assign no equipment";
 	"oolite-primablemanager-selected-text" = "(selected)";
 
-	"oolite-primablemanager-completed" = "Equipment configuration is complete.\n\nFirst fast activation (defensive):\n  [oolite-primable-a]\n\nSecond fast activation (offensive):\n  [oolite-primable-b]";
+	"oolite-primablemanager-completed" = "Equipment configuration is complete.\n\nFirst fast activation key ([oolite-primablemanager-slot-defensive]):\n  [oolite-primable-a]\n\nSecond fast activation key ([oolite-primablemanager-slot-offensive]):\n  [oolite-primable-b]";
 
 
 	// tutorial


### PR DESCRIPTION
The goal here is to make the fast activation screen clearer, so the player doesn't have to know what key is associated with "fast activate defense" and "fast activate offense". 