### PR TITLE
HDR output display detection on Windows

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -31,9 +31,9 @@ ifeq ($(GNUSTEP_HOST_OS),mingw32)
 
     ADDITIONAL_INCLUDE_DIRS      = -I$(WIN_DEPS_DIR)/include -I$(JS_INC_DIR) -Isrc/SDL -Isrc/Core -Isrc/BSDCompat -Isrc/Core/Scripting -Isrc/Core/Materials -Isrc/Core/Entities -Isrc/Core/OXPVerifier -Isrc/Core/Debug -Isrc/Core/Tables -Isrc/Core/MiniZip
     ADDITIONAL_OBJC_LIBS         = -L$(WIN_DEPS_DIR)/lib -lglu32 -lopengl32 -lopenal32.dll -lpng14.dll -lmingw32 -lSDLmain -lSDL -lvorbisfile.dll -lvorbis.dll -lz -lgnustep-base -l$(JS_IMPORT_LIBRARY) -lwinmm -mwindows
-    ADDITIONAL_CFLAGS            = -DWIN32 -DNEED_STRLCPY `sdl-config --cflags` -mtune=generic
+    ADDITIONAL_CFLAGS            = -DWIN32 -DNEED_STRLCPY `sdl-config --cflags` -mtune=generic -DWINVER=0x0601
 # note the vpath stuff above isn't working for me, so adding src/SDL and src/Core explicitly
-    ADDITIONAL_OBJCFLAGS         = -DLOADSAVEGUI -DWIN32 -DXP_WIN -Wno-import -std=gnu99 `sdl-config --cflags` -mtune=generic
+    ADDITIONAL_OBJCFLAGS         = -DLOADSAVEGUI -DWIN32 -DXP_WIN -Wno-import -std=gnu99 `sdl-config --cflags` -mtune=generic -DWINVER=0x0601
     ifneq ($(HOST_ARCH),x86_64)
         ADDITIONAL_LDFLAGS       += -Wl,--large-address-aware
 #     else

--- a/src/SDL/MyOpenGLView.h
+++ b/src/SDL/MyOpenGLView.h
@@ -258,6 +258,7 @@ extern int debug;
 - (void) setHDRPaperWhiteBrightness:(float)newPaperWhiteBrightness;
 #endif
 - (BOOL) hdrOutput;
+- (BOOL) isOutputDisplayHDREnabled;
 
 - (void) grabMouseInsideGameWindow:(BOOL) value;
 


### PR DESCRIPTION
The main feature this PR implements is HDR display device detection capability on Windows. If -hdr has been passed as startup parameter, we now check whether the primary display (which is where Oolite starts on) is HDR enabled and notify the user in case it is not. If no HDR display capable primary device has been found, the user has the choice to launch the game anyway or quit.

Additionally contained in this PR are the following:
- The minimum Wibndows version requirement is hereby raised to Windows 7 64-bit. This is due to the Win APIs used for HDR detection.
- The main thread's priority is now elevated to Time Critical when the game window has focus, When focus is lost, the main thread is returned to normal priority again.
- If a valid window surface could not be created at startup, Oolite issues a message that subsequent game launches will be skipping the splash screen, in a last ditch attempt for a fix. It does not, however, update the defaults file with the -nosplash screen setting, as it is supposed to. This is now fixed.


