### PR TITLE
GUI background and foreground images are now treated as having SRGBA internal format

### DIFF
--- a/src/Core/GuiDisplayGen.m
+++ b/src/Core/GuiDisplayGen.m
@@ -987,9 +987,20 @@ static BOOL _refreshStarChart = NO;
 
 static OOTexture *TextureForGUITexture(NSDictionary *descriptor)
 {
+	/*
+		GUI textures like backgrounds, foregrounds etc. are not processed in any way after loading. However, they are
+		subject to tone nmapping and gamma correction at the end of the render pass. So we need to declare them as
+		SRGBA textures here so that OpenGL will automatically convert them to linear space upon loading and the
+		subsequent tone mapping and gamma correction shader operations will not result in heavy distortion of their
+		colors.
+		
+		Also, remember that if no shaders are in use (as in lower detail levels), then we don't need to declare anything.
+	*/
+	uint32_t srgbaOption = 0UL;
+	if ([UNIVERSE useShaders])  srgbaOption = kOOTextureSRGBA;
 	return [OOTexture textureWithName:[descriptor oo_stringForKey:@"name"]
 							 inFolder:@"Images"
-							  options:kOOTextureDefaultOptions | kOOTextureNoShrink
+							  options:kOOTextureDefaultOptions | kOOTextureNoShrink | srgbaOption
 						   anisotropy:kOOTextureDefaultAnisotropy
 							  lodBias:kOOTextureDefaultLODBias];
 }

--- a/src/Core/Materials/OOConcreteTexture.m
+++ b/src/Core/Materials/OOConcreteTexture.m
@@ -676,7 +676,7 @@ static BOOL DecodeFormat(OOTextureDataFormat format, uint32_t options, GLenum *o
 	{
 		case kOOTextureDataRGBA:
 			*outFormat = GL_RGBA;
-			*outInternalFormat = GL_RGBA;
+			*outInternalFormat = options & kOOTextureSRGBA ? GL_SRGB_ALPHA : GL_RGBA;
 			*outType = RGBA_IMAGE_TYPE;
 			return YES;
 			

--- a/src/Core/Materials/OOTexture.h
+++ b/src/Core/Materials/OOTexture.h
@@ -60,6 +60,8 @@ enum
 	kOOTextureAlphaMask				= 0x000800UL,	// Single-channel texture should be GL_ALPHA, not GL_LUMINANCE. No effect for multi-channel textures.
 	kOOTextureAllowCubeMap			= 0x001000UL,
 	
+	kOOTextureSRGBA					= 0x002000UL,
+	
 	kOOTextureExtractChannelMask	= 0x700000UL,
 	kOOTextureExtractChannelNone	= 0x000000UL,
 	kOOTextureExtractChannelR		= 0x100000UL,	// 001
@@ -83,6 +85,7 @@ enum
 									| kOOTextureNoFNFMessage
 									| kOOTextureNeverScale
 									| kOOTextureAlphaMask
+									| kOOTextureSRGBA
 									| kOOTextureExtractChannelMask,
 	
 	kOOTextureFlagsAllowedForRectangleTexture =


### PR DESCRIPTION
GUI textures like backgrounds, foregrounds etc. are not processed in any way after having been loaded. However, they are subject to tone nmapping and gamma correction at the end of the render pass because they are part of the final scene texture. So we need to declare them as SRGBA textures when they are loaded so that OpenGL will automatically convert them to linear space and the subsequent tone mapping and gamma correction shader operations will not result in heavy distortion of their colors due to over-correction.

This should fix #412.