### PR TITLE
Dark Mode Support on Windows

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -30,7 +30,7 @@ ifeq ($(GNUSTEP_HOST_OS),mingw32)
     endif
 
     ADDITIONAL_INCLUDE_DIRS      = -I$(WIN_DEPS_DIR)/include -I$(JS_INC_DIR) -Isrc/SDL -Isrc/Core -Isrc/BSDCompat -Isrc/Core/Scripting -Isrc/Core/Materials -Isrc/Core/Entities -Isrc/Core/OXPVerifier -Isrc/Core/Debug -Isrc/Core/Tables -Isrc/Core/MiniZip
-    ADDITIONAL_OBJC_LIBS         = -L$(WIN_DEPS_DIR)/lib -lglu32 -lopengl32 -lopenal32.dll -lpng14.dll -lmingw32 -lSDLmain -lSDL -lvorbisfile.dll -lvorbis.dll -lz -lgnustep-base -l$(JS_IMPORT_LIBRARY) -lwinmm -mwindows
+    ADDITIONAL_OBJC_LIBS         = -L$(WIN_DEPS_DIR)/lib -lglu32 -lopengl32 -lopenal32.dll -lpng14.dll -lmingw32 -lSDLmain -lSDL -lvorbisfile.dll -lvorbis.dll -lz -lgnustep-base -l$(JS_IMPORT_LIBRARY) -ldwmapi -lwinmm -mwindows
     ADDITIONAL_CFLAGS            = -DWIN32 -DNEED_STRLCPY `sdl-config --cflags` -mtune=generic -DWINVER=0x0601 -D_WIN32_WINNT=0x0601
 # note the vpath stuff above isn't working for me, so adding src/SDL and src/Core explicitly
     ADDITIONAL_OBJCFLAGS         = -DLOADSAVEGUI -DWIN32 -DXP_WIN -Wno-import -std=gnu99 `sdl-config --cflags` -mtune=generic -DWINVER=0x0601 -D_WIN32_WINNT=0x0601

--- a/src/SDL/MyOpenGLView.h
+++ b/src/SDL/MyOpenGLView.h
@@ -255,6 +255,8 @@ extern int debug;
 #if OOLITE_WINDOWS
 - (BOOL) getCurrentMonitorInfo:(MONITORINFOEX *)mInfo;
 - (MONITORINFOEX) currentMonitorInfo;
+- (void) refreshDarKOrLightMode;
+- (BOOL) isDarkModeOn;
 - (BOOL) atDesktopResolution;
 - (float) hdrMaxBrightness;
 - (void) setHDRMaxBrightness:(float)newMaxBrightness;

--- a/src/SDL/MyOpenGLView.m
+++ b/src/SDL/MyOpenGLView.m
@@ -2711,7 +2711,7 @@ HRESULT WINAPI DwmSetWindowAttribute (HWND hwnd, DWORD dwAttribute, LPCVOID pvAt
 	}
 	else
 	{
-		windowSize=NSMakeSize(800, 600);
+		windowSize=NSMakeSize(1024, 576);
 	}
 	currentWindowSize=windowSize;
 	return windowSize;
@@ -2791,7 +2791,7 @@ HRESULT WINAPI DwmSetWindowAttribute (HWND hwnd, DWORD dwAttribute, LPCVOID pvAt
 				[[mode objectForKey: kOODisplayHeight] intValue]);
 	}
 	OOLog(@"display.mode.unknown", @"%@", @"Screen size unknown!");
-	return NSMakeSize(800, 600);
+	return NSMakeSize(1024, 576);
 }
 
 


### PR DESCRIPTION
Apps by default are set to render their windows in light mode for compatibility reasons. However, ideally they should conform to the users' preferences and the light / dark mode setting happens to be one of the most important ones due to its immediate visible effect on presentation. With this PR, the Windows personalization dark / light color mode setting is now honored by the game window.

Oolite now detects the light / dark UI mode setting and adjusts itself as required. Additionally, it listens for real-time changes of the setting and can re-adjust on the fly if the user change their preference with the game window open and running.

Example image showing dark mode: 

![Oolite Dark Mode](https://imgur.com/be1dG9R.png)