### PR TITLE
Adding ability to define additional keys on a mission screen

### DIFF
--- a/src/Core/Entities/PlayerEntity.h
+++ b/src/Core/Entities/PlayerEntity.h
@@ -384,7 +384,7 @@ typedef enum
 	NSString				*_missionTitle;
 	NSInteger /*OOGUIRow*/	missionTextRow;
 	NSString				*missionChoice;
-	
+	NSString				*missionKeyPress;
 	BOOL					_missionWithCallback;
 	BOOL					_missionAllowInterrupt;
 	BOOL					_missionTextEntry;
@@ -693,6 +693,9 @@ typedef enum
 	NSMutableArray			*customEquipActivation;
 	NSMutableArray			*customActivatePressed;
 	NSMutableArray			*customModePressed;
+
+	// dict to hold extra keys for missions screen.
+	NSDictionary			*extraMissionKeys;
 
 	// save-file
 	NSString				*save_path;
@@ -1229,6 +1232,8 @@ typedef enum
 - (void) setMissionBackgroundSpecial:(NSString *)special;
 - (void) setMissionExitScreen:(OOGUIScreenID)screen;
 - (OOGUIScreenID) missionExitScreen;
+- (void) clearExtraMissionKeys;
+- (void) setExtraMissionKeys:(NSDictionary *)keys;
 
 // Nasty hack to keep background textures around while on equip screens.
 - (NSDictionary *) equipScreenBackgroundDescriptor;

--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -13239,6 +13239,26 @@ else _dockTarget = NO_TARGET;
 }
 
 
+- (void) clearExtraMissionKeys
+{
+	[extraMissionKeys release];
+	extraMissionKeys = nil;
+}
+
+
+- (void) setExtraMissionKeys:(NSDictionary *)keys
+{
+	NSString *key = nil;
+	NSMutableDictionary *final = [[NSMutableDictionary alloc] init];
+	foreach (key, [keys allKeys])
+	{
+		[final setObject:[self processKeyCode:[keys oo_arrayForKey:key]] forKey:key];
+	}
+	extraMissionKeys = [final copy];
+	[final release];
+}
+
+
 #ifndef NDEBUG
 - (void)dumpSelfState
 {

--- a/src/Core/Entities/PlayerEntityControls.m
+++ b/src/Core/Entities/PlayerEntityControls.m
@@ -5257,6 +5257,7 @@ static BOOL autopilot_pause;
 					selectPressed = NO;
 					[self pollMissionInterruptControls];
 				}
+				[extraKey release];
 			}
 			break;
 			

--- a/src/Core/Entities/PlayerEntityControls.m
+++ b/src/Core/Entities/PlayerEntityControls.m
@@ -148,6 +148,7 @@ static BOOL				next_planet_info_pressed;
 static BOOL				previous_planet_info_pressed;
 static BOOL				home_info_pressed;
 static BOOL				target_info_pressed;
+static BOOL				extra_key_pressed;
 static NSPoint				mouse_click_position;
 static NSPoint				centre_at_mouse_click;
 
@@ -3883,7 +3884,7 @@ static NSTimeInterval	time_last_frame;
 {
 	MyOpenGLView	*gameView = [UNIVERSE gameView];
 	GuiDisplayGen	*gui = [UNIVERSE gui];
-	
+
 	[self keyMapperInputHandler: gui view: gameView];
 	leftRightKeyPressed = [self checkKeyPress:n_key_gui_arrow_right] || [self checkKeyPress:n_key_gui_arrow_left] || [self checkKeyPress:n_key_gui_page_up] || [self checkKeyPress:n_key_gui_page_down];
 	if (leftRightKeyPressed)
@@ -5178,7 +5179,7 @@ static BOOL autopilot_pause;
 				[self refreshMissionScreenTextEntry];
 				if ([self checkKeyPress:n_key_gui_select] || [gameView isDown:gvMouseDoubleClick])	//  '<enter/return>' or double click
 				{
-					[self setMissionChoice:[gameView typedString]];
+					[self setMissionChoice:[gameView typedString] keyPress:@"enter"];
 					[[OOMusicController sharedController] stopMissionMusic];
 					[self playDismissedMissionScreen];
 					
@@ -5214,7 +5215,24 @@ static BOOL autopilot_pause;
 			else
 			{
 				[self handleGUIUpDownArrowKeys];
-				if ([self checkKeyPress:n_key_gui_select] || [gameView isDown:gvMouseDoubleClick])	//  '<enter/return>' or double click
+				NSString *extraKey = @"";
+				if (extraMissionKeys)
+				{
+					NSString *key = nil;
+					foreach (key, [extraMissionKeys allKeys])
+					{
+						if ([self checkKeyPress:[extraMissionKeys oo_arrayForKey:key]]) {
+							if (!extra_key_pressed)
+							{
+								extraKey = [key copy];
+							}
+							extra_key_pressed = YES;
+						}
+						else
+						extra_key_pressed = NO;
+					}
+				}
+				if ([self checkKeyPress:n_key_gui_select] || [gameView isDown:gvMouseDoubleClick] || [extraKey length] > 0)	//  '<enter/return>' or double click
 				{
 					if ([gameView isDown:gvMouseDoubleClick])
 					{
@@ -5223,7 +5241,8 @@ static BOOL autopilot_pause;
 					}
 					if (!selectPressed)
 					{
-						[self setMissionChoice:[gui selectedRowKey]];
+						if ([extraKey length] == 0) extraKey = @"enter";
+						[self setMissionChoice:[gui selectedRowKey] keyPress:extraKey];
 						[[OOMusicController sharedController] stopMissionMusic];
 						[self playDismissedMissionScreen];
 						

--- a/src/Core/Entities/PlayerEntityLegacyScriptEngine.h
+++ b/src/Core/Entities/PlayerEntityLegacyScriptEngine.h
@@ -108,6 +108,7 @@ typedef enum
 - (NSString *) sunGoneNova_bool;		// returns whether the sun has gone nova
 
 - (NSString *) missionChoice_string;	// returns nil or the key for the chosen option
+- (NSString *) missionKeyPress_string;
 
 - (NSNumber *) dockedTechLevel_number;
 - (NSString *) dockedStationName_string;	// returns 'NONE' if the player isn't docked, [station name] if it is, 'UNKNOWN' otherwise

--- a/src/Core/Entities/PlayerEntityLegacyScriptEngine.m
+++ b/src/Core/Entities/PlayerEntityLegacyScriptEngine.m
@@ -1070,6 +1070,12 @@ static int shipsFound;
 }
 
 
+- (NSString *) missionKeyPress_string
+{
+	return missionKeyPress;
+}
+
+
 - (NSNumber *) dockedTechLevel_number
 {
 	StationEntity *dockedStation = [self dockedStation];

--- a/src/Core/Entities/PlayerEntityScriptMethods.h
+++ b/src/Core/Entities/PlayerEntityScriptMethods.h
@@ -49,6 +49,8 @@ MA 02110-1301, USA.
 
 - (void) setMissionChoice:(NSString *)newChoice;
 - (void) setMissionChoice:(NSString *)newChoice withEvent:(BOOL) withEvent;
+- (void) setMissionChoice:(NSString *)newChoice keyPress:(NSString *)keyPress;
+- (void) setMissionChoice:(NSString *)newChoice keyPress:(NSString *)keyPress withEvent:(BOOL) withEvent;
 - (void) allowMissionInterrupt;
 
 - (OOTimeDelta) scriptTimer;

--- a/src/Core/Entities/PlayerEntityScriptMethods.m
+++ b/src/Core/Entities/PlayerEntityScriptMethods.m
@@ -190,11 +190,23 @@ MA 02110-1301, USA.
 
 - (void) setMissionChoice:(NSString *)newChoice
 {
-	[self setMissionChoice:newChoice withEvent:YES];
+	[self setMissionChoice:newChoice keyPress:@"" withEvent:YES];
 }
 
 
 - (void) setMissionChoice:(NSString *)newChoice withEvent:(BOOL)withEvent
+{
+	[self setMissionChoice:newChoice keyPress:@"" withEvent:withEvent];
+}
+
+
+- (void) setMissionChoice:(NSString *)newChoice keyPress:(NSString *)keyPress
+{
+	[self setMissionChoice:newChoice keyPress:keyPress withEvent:YES];
+}
+
+
+- (void) setMissionChoice:(NSString *)newChoice keyPress:(NSString *)keyPress withEvent:(BOOL)withEvent
 {
 	BOOL equal = [newChoice isEqualToString:missionChoice] || (newChoice == missionChoice);	// Catch both being nil as well
 	if (!equal)
@@ -211,6 +223,12 @@ MA 02110-1301, USA.
 			[missionChoice autorelease];
 			missionChoice = [newChoice copy];
 		}
+	}
+	equal = [keyPress isEqualToString:missionKeyPress] || (keyPress == missionKeyPress);
+	if (!equal) 
+	{
+		[missionKeyPress autorelease];
+		missionKeyPress = [keyPress copy];
 	}
 }
 

--- a/src/Core/Entities/ShipEntity.m
+++ b/src/Core/Entities/ShipEntity.m
@@ -3619,7 +3619,7 @@ ShipEntity* doOctreesCollide(ShipEntity* prime, ShipEntity* other)
 			maxEnergy += 256.0f;
 			energy_recharge_rate *= 1.5;
 		}
-	}
+	} 
 	// add the equipment
 	[_equipment addObject:equipmentKey];
 	[self doScriptEvent:OOJSID("equipmentAdded") withArgument:equipmentKey];


### PR DESCRIPTION
Presently, the only key a mission screen can watch for is the "enter" key, when the player presses it on a choice. This limits what can be done with UI design.

This PR aims to correct this by allowing any key (including function keys or shift/ctrl/alt combinations) to be registered on a mission screen, with the callback function being called when one is pressed. Two changes are needed for a mission screen to make use of this feature.

1. Add the "registerKeys" property to the options dictionary. This property lists all the desired keys for the mission screen in a dictionary object. For example:
```
this.$openScreen = function () {
    var opts = {
        screenID: "myScreenID",
        title: "Sample Title",
        message: "A sample screen.",
        choices: {"default":{"text":"Press ESC to exit"}},
        registerKeys: {"escape":[{key:"esc"}]}
    };
    mission.runScreen(opts, this.$myScreenHandler.bind(this), this);
}
```
2. Add the "keyPress" parameter to the callback function. This parameter is in addition to the existing "choice" parameter. It will contain the dictionary key name for the registered key. For example:
```
this.$myScreenHandler = function(choice, keyPress) {
    if (keyPress != "escape") this.$openScreen(); 
}
```

I've put together 3 examples demonstrating the new functionality:
[https://app.box.com/s/hinwftyta6krpensmygi1ydcbd2e9xw7](url) Uses the arrow keys to enter a 4 digit code.
[https://app.box.com/s/cxdeap7fnlakui57vyoebdyelsh247iz](url) Allows character entry to search for systems on the chart.
[https://app.box.com/s/w2405pvgs2dlxq22y154ubwjx0vhxchr](url) Recreates the F3F3 Shipyard, responding to the arrow up/down keys to change the displayed ship.
