### PR TITLE
Adds ability to define custom keys on most gui screens

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -324,6 +324,7 @@ OOLITE_SCRIPTING_FILES = \
     OOJSFunction.m \
     OOJSGlobal.m \
     OOJSInterfaceDefinition.m \
+    OOJSGuiScreenKeyDefinition.m \
     OOJSManifest.m \
     OOJSMission.m \
     OOJSMissionVariables.m \

--- a/Oolite.xcodeproj/project.pbxproj
+++ b/Oolite.xcodeproj/project.pbxproj
@@ -193,6 +193,8 @@
 		1A38B4AD0B988532001ED4A0 /* OOLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A38B4AB0B988532001ED4A0 /* OOLogging.m */; settings = {COMPILER_FLAGS = "-fvisibility=default"; }; };
 		1A38E9E31603C7A500EE19F1 /* OOJSInterfaceDefinition.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A38E9E11603C7A500EE19F1 /* OOJSInterfaceDefinition.h */; };
 		1A38E9E41603C7A500EE19F1 /* OOJSInterfaceDefinition.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A38E9E21603C7A500EE19F1 /* OOJSInterfaceDefinition.m */; };
+		1A38E9E71603C7A500EE19F1 /* OOJSGuiScreenKeyDefinition.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A38E9E51603C7A500EE19F1 /* OOJSGuiScreenKeyDefinition.h */; };
+		1A38E9E81603C7A500EE19F1 /* OOJSGuiScreenKeyDefinition.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A38E9E61603C7A500EE19F1 /* OOJSGuiScreenKeyDefinition.m */; };
 		1A3A04620BC547DC00B5E2D9 /* OOTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A3A04610BC547DC00B5E2D9 /* OOTypes.h */; };
 		1A3ACFEB0C5FF33A00EC50A7 /* OOJSShip.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A3ACFE90C5FF33A00EC50A7 /* OOJSShip.h */; };
 		1A3ACFEC0C5FF33A00EC50A7 /* OOJSShip.m in Sources */ = {isa = PBXBuildFile; fileRef = 1A3ACFEA0C5FF33A00EC50A7 /* OOJSShip.m */; };
@@ -1123,6 +1125,8 @@
 		1A38B4AB0B988532001ED4A0 /* OOLogging.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OOLogging.m; sourceTree = "<group>"; };
 		1A38E9E11603C7A500EE19F1 /* OOJSInterfaceDefinition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OOJSInterfaceDefinition.h; sourceTree = "<group>"; };
 		1A38E9E21603C7A500EE19F1 /* OOJSInterfaceDefinition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OOJSInterfaceDefinition.m; sourceTree = "<group>"; };
+		1A38E9E51603C7A500EE19F1 /* OOJSGuiScreenKeyDefinition.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OOJSGuiScreenKeyDefinition.h; sourceTree = "<group>"; };
+		1A38E9E61603C7A500EE19F1 /* OOJSGuiScreenKeyDefinition.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OOJSGuiScreenKeyDefinition.m; sourceTree = "<group>"; };
 		1A38E9E51603C7ED00EE19F1 /* oolite-contracts-parcels.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = "oolite-contracts-parcels.js"; sourceTree = "<group>"; };
 		1A3A04610BC547DC00B5E2D9 /* OOTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OOTypes.h; sourceTree = "<group>"; };
 		1A3ACFE90C5FF33A00EC50A7 /* OOJSShip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OOJSShip.h; sourceTree = "<group>"; };
@@ -2323,6 +2327,8 @@
 				1A0942C812D7C011003B6273 /* OOJSFrameCallbacks.m */,
 				1A38E9E11603C7A500EE19F1 /* OOJSInterfaceDefinition.h */,
 				1A38E9E21603C7A500EE19F1 /* OOJSInterfaceDefinition.m */,
+				1A38E9E51603C7A500EE19F1 /* OOJSGuiScreenKeyDefinition.h */,
+				1A38E9E61603C7A500EE19F1 /* OOJSGuiScreenKeyDefinition.m */,
 				1AD8522C17947C9400CBE743 /* OOJSPopulatorDefinition.h */,
 				1AD8522D17947C9500CBE743 /* OOJSPopulatorDefinition.m */,
 			);
@@ -3448,6 +3454,7 @@
 				1A72F87215E5658E00281337 /* OOJSVisualEffect.h in Headers */,
 				1A401F8815E7AF7B004CDF95 /* OOPrimaryWindow.h in Headers */,
 				1A38E9E31603C7A500EE19F1 /* OOJSInterfaceDefinition.h in Headers */,
+				1A38E9E71603C7A500EE19F1 /* OOJSGuiScreenKeyDefinition.h in Headers */,
 				1AAEE9DA161F7523003A5A1E /* OOStringExpander.h in Headers */,
 				1AD8522517947BD600CBE743 /* OOHPVector.h in Headers */,
 				1AD8522E17947C9500CBE743 /* OOJSPopulatorDefinition.h in Headers */,
@@ -3986,6 +3993,7 @@
 				1A72F87315E5658E00281337 /* OOJSVisualEffect.m in Sources */,
 				1A401F8915E7AF7B004CDF95 /* OOPrimaryWindow.m in Sources */,
 				1A38E9E41603C7A500EE19F1 /* OOJSInterfaceDefinition.m in Sources */,
+				1A38E9E81603C7A500EE19F1 /* OOJSGuiScreenKeyDefinition.m in Sources */,
 				1AAEE9DB161F7523003A5A1E /* OOStringExpander.m in Sources */,
 				1AD3C339163A92F600469C4D /* OOOpenGLStateManager.m in Sources */,
 				1AD8522617947BD600CBE743 /* OOHPVector.m in Sources */,

--- a/src/Core/Entities/PlayerEntity.h
+++ b/src/Core/Entities/PlayerEntity.h
@@ -37,7 +37,7 @@ MA 02110-1301, USA.
 @class GuiDisplayGen, OOTrumble, MyOpenGLView, HeadUpDisplay, ShipEntity;
 @class OOSound, OOSoundSource, OOSoundReferencePoint;
 @class OOJoystickManager, OOTexture, OOLaserShotEntity;
-@class StickProfileScreen;
+@class StickProfileScreen, OOJSGuiScreenKeyDefinition;
 
 #define ALLOW_CUSTOM_VIEWS_WHILE_PAUSED	1
 #define SCRIPT_TIMER_INTERVAL			10.0
@@ -697,6 +697,8 @@ typedef enum
 	// dict to hold extra keys for missions screen.
 	NSDictionary			*extraMissionKeys;
 
+	NSMutableDictionary		*extraGuiScreenKeys;
+
 	// save-file
 	NSString				*save_path;
 	NSString				*scenarioKey;
@@ -1234,6 +1236,10 @@ typedef enum
 - (OOGUIScreenID) missionExitScreen;
 - (void) clearExtraMissionKeys;
 - (void) setExtraMissionKeys:(NSDictionary *)keys;
+
+- (void) clearExtraGuiScreenKeys:(OOGUIScreenID)gui key:(NSString *)key;
+- (BOOL) setExtraGuiScreenKeys:(OOGUIScreenID)gui definition:(OOJSGuiScreenKeyDefinition *)definition;
+
 
 // Nasty hack to keep background textures around while on equip screens.
 - (NSDictionary *) equipScreenBackgroundDescriptor;

--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -77,6 +77,7 @@ MA 02110-1301, USA.
 #import "OOScriptTimer.h"
 #import "OOJSEngineTimeManagement.h"
 #import "OOJSInterfaceDefinition.h"
+#import "OOJSGuiScreenKeyDefinition.h"
 #import "OOConstToJSString.h"
 
 #import "OOJoystickManager.h"
@@ -2432,6 +2433,8 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 	DESTROY(customEquipActivation);
 	DESTROY(customActivatePressed);
 	DESTROY(customModePressed);
+
+	DESTROY(extraGuiScreenKeys);
 
 	[super dealloc];
 }
@@ -13256,6 +13259,95 @@ else _dockTarget = NO_TARGET;
 	}
 	extraMissionKeys = [final copy];
 	[final release];
+}
+
+
+- (void) clearExtraGuiScreenKeys:(OOGUIScreenID)gui key:(NSString *)key
+{
+	NSMutableArray *keydefs = [extraGuiScreenKeys objectForKey:[NSString stringWithFormat:@"%d",gui]];
+	NSInteger i = [keydefs count];
+	NSDictionary *def = nil;
+	while (i--) 
+	{
+		def = [keydefs objectAtIndex:i];
+		if (def && [[def oo_stringForKey:@"name"] isEqualToString:key]) 
+		{
+			[keydefs removeObjectAtIndex:i];
+			break;
+		}
+	}
+	// do we have to put the array back, or does the reference update the source?
+}
+
+
+- (BOOL) setExtraGuiScreenKeys:(OOGUIScreenID)gui definition:(OOJSGuiScreenKeyDefinition *)definition
+{
+	// process all the keys in the definition
+	BOOL result = YES;
+	NSMutableArray *newarray = nil;
+	NSString *key = nil;	
+	NSMutableDictionary *final = [[NSMutableDictionary alloc] init];
+	NSDictionary *keys = [definition registerKeys];
+	NSMutableArray *checklist = [[NSMutableArray alloc] init];
+
+	foreach (key, [keys allKeys])
+	{
+		NSArray *item = [self processKeyCode:[keys oo_arrayForKey:key]];
+		[checklist addObject:item];
+		[final setObject:item forKey:key];
+	}
+	[definition setRegisterKeys:[final copy]];
+	[final release];
+
+	/// create the dictionary, if it doesn't already exist
+	if (!extraGuiScreenKeys) 
+	{
+		extraGuiScreenKeys = [[NSMutableDictionary alloc] init];
+	}
+
+	if (![extraGuiScreenKeys objectForKey:[NSString stringWithFormat:@"%d",gui]]) 
+	{
+		// brand new - just add
+		newarray = [[NSMutableArray alloc] init];
+	}
+	else 
+	{
+		newarray = [[extraGuiScreenKeys objectForKey:[NSString stringWithFormat:@"%d",gui]] mutableCopy];
+		NSInteger i = [newarray count];
+		NSInteger j = 0;
+		OOJSGuiScreenKeyDefinition *def_existing = nil;
+		while (i--) 
+		{
+			def_existing = [newarray objectAtIndex:i]; 
+			// if we find this name already in the array, remove it
+			if (def_existing && [[def_existing name] isEqualToString:[definition name]])
+			{
+				[newarray removeObjectAtIndex:i];
+			}
+			else 
+			{
+				// check whether any of those keycodes is already in use on this screen
+				NSDictionary *keydefs = [def_existing registerKeys];
+				j = [checklist count];
+				foreach (key, [keydefs allKeys])
+				{
+					while (j--) 
+					{
+						if ([[NSString stringWithFormat:@"%@",[keydefs objectForKey:key]] isEqualToString:[NSString stringWithFormat:@"%@",[checklist objectAtIndex:j]]]) 
+						{
+							result = NO;
+							OOLog(kOOLogException, @"***** Exception in setExtraGuiScreenKeys: %@ : %@ (%@)", @"invalid key settings", @"key already in use", key);
+						}
+					}
+				}
+			}
+		}
+	}
+	[newarray addObject:definition];
+	// only add the item if there were no errors
+	if (result) [extraGuiScreenKeys setObject:[newarray mutableCopy] forKey:[NSString stringWithFormat:@"%d",gui]];
+	[newarray release];
+	return result;
 }
 
 

--- a/src/Core/Scripting/OOJSGuiScreenKeyDefinition.h
+++ b/src/Core/Scripting/OOJSGuiScreenKeyDefinition.h
@@ -1,0 +1,54 @@
+/*
+
+OOJSGuiScreenKeyDefinition.h
+
+
+Oolite
+Copyright (C) 2004-2013 Giles C Williams and contributors
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+
+*/
+
+#import "OOJSScript.h"
+#include <jsapi.h>
+
+@interface OOJSGuiScreenKeyDefinition: OOWeakRefObject
+{
+@private
+	jsval				_callback;
+	JSObject			*_callbackThis;
+	OOJSScript			*_owningScript;
+
+	NSString			*_name;
+	NSDictionary		*_registerKeys;
+}
+
+- (NSString *)name;
+- (void)setName:(NSString *)name;
+- (NSDictionary *)registerKeys;
+- (void)setRegisterKeys:(NSDictionary *)registerKeys;
+- (jsval)callback;
+- (void)setCallback:(jsval)callback;
+- (JSObject *)callbackThis;
+- (void)setCallbackThis:(JSObject *)callbackthis;
+
+- (void)runCallback:(NSString *)key;
+
+- (NSComparisonResult)interfaceCompare:(OOJSGuiScreenKeyDefinition *)other;
+
+@end
+

--- a/src/Core/Scripting/OOJSGuiScreenKeyDefinition.m
+++ b/src/Core/Scripting/OOJSGuiScreenKeyDefinition.m
@@ -1,0 +1,160 @@
+/*
+
+OOJSGuiScreenKeyDefinition.m
+
+
+Oolite
+Copyright (C) 2004-2013 Giles C Williams and contributors
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+MA 02110-1301, USA.
+
+*/
+
+#import "OOJSGuiScreenKeyDefinition.h"
+//#import "OOJavaScriptEngine.h"
+
+
+@implementation OOJSGuiScreenKeyDefinition
+
+- (id) init {
+	self = [super init];
+	_callback = JSVAL_VOID;
+	_callbackThis = NULL;
+
+	_owningScript = [[OOJSScript currentlyRunningScript] weakRetain];
+
+	[[NSNotificationCenter defaultCenter] addObserver:self
+												 selector:@selector(deleteJSPointers)
+												 name:kOOJavaScriptEngineWillResetNotification
+											   object:[OOJavaScriptEngine sharedEngine]];
+
+	return self;
+}
+
+- (void) deleteJSPointers
+{
+
+	JSContext				*context = OOJSAcquireContext();
+	_callback = JSVAL_VOID;
+	_callbackThis = NULL;
+	JS_RemoveValueRoot(context, &_callback);
+	JS_RemoveObjectRoot(context, &_callbackThis);
+
+	OOJSRelinquishContext(context);
+
+	[[NSNotificationCenter defaultCenter] removeObserver:self
+													name:kOOJavaScriptEngineWillResetNotification
+												  object:[OOJavaScriptEngine sharedEngine]];
+
+}
+
+- (void) dealloc 
+{
+	[_owningScript release];
+
+	[self deleteJSPointers];
+
+	[super dealloc];
+}
+
+- (NSString *)name 
+{
+	return _name;
+}
+
+
+- (void)setName:(NSString *)name
+{
+	[_name autorelease];
+	_name = [name retain];
+}
+
+
+- (NSDictionary *)registerKeys
+{
+	return _registerKeys;
+}
+
+
+- (void)setRegisterKeys:(NSDictionary *)registerKeys
+{
+	[_registerKeys release];
+	_registerKeys = [registerKeys copy];
+}
+
+
+- (jsval)callback
+{
+	return _callback;
+}
+
+
+- (void)setCallback:(jsval)callback
+{
+	JSContext				*context = OOJSAcquireContext();
+	JS_RemoveValueRoot(context, &_callback);
+	_callback = callback;
+	OOJSAddGCValueRoot(context, &_callback, "OOJSGuiScreenKeyDefinition callback function");
+	OOJSRelinquishContext(context);
+}
+
+
+- (JSObject *)callbackThis
+{
+	return _callbackThis;
+}
+
+
+- (void)setCallbackThis:(JSObject *)callbackThis
+{
+	JSContext				*context = OOJSAcquireContext();
+	JS_RemoveObjectRoot(context, &_callbackThis);
+	_callbackThis = callbackThis;
+	OOJSAddGCObjectRoot(context, &_callbackThis, "OOJSGuiScreenKeyDefinition callback this");
+	OOJSRelinquishContext(context);
+}
+
+
+- (void)runCallback:(NSString *)key
+{
+	OOJavaScriptEngine *engine = [OOJavaScriptEngine sharedEngine];
+	JSContext			*context = OOJSAcquireContext();		
+	jsval					rval = JSVAL_VOID;
+
+	jsval         cKey = OOJSValueFromNativeObject(context, key);
+
+	OOJSScript *owner = [_owningScript retain]; // local copy needed
+	[OOJSScript pushScript:owner];
+	
+	[engine callJSFunction:_callback
+				 forObject:_callbackThis
+					  argc:1
+					  argv:&cKey
+					result:&rval];
+	
+	[OOJSScript popScript:owner];
+	[owner release];
+
+	OOJSRelinquishContext(context);
+}
+
+
+- (NSComparisonResult)interfaceCompare:(OOJSGuiScreenKeyDefinition *)other
+{
+    return [_name caseInsensitiveCompare:[other name]];
+}
+
+@end

--- a/src/Core/Scripting/OOJSMission.m
+++ b/src/Core/Scripting/OOJSMission.m
@@ -626,15 +626,6 @@ static JSBool MissionRunScreen(JSContext *context, uintN argc, jsval *vp)
 
 	[UNIVERSE removeDemoShips];	// remove any demoship or miniature planet that may be remaining from previous screens
 	
-	if ([player status] == STATUS_IN_FLIGHT)
-	{
-		OOStandardsError(@"Mission screens should not be used while in flight");
-		if (OOEnforceStandards())
-		{
-			return NO;
-		}
-	}
-
 	ShipEntity *demoShip = nil;
 	if (JS_GetProperty(context, params, "model", &value) && !JSVAL_IS_VOID(value))
 	{
@@ -673,9 +664,17 @@ static JSBool MissionRunScreen(JSContext *context, uintN argc, jsval *vp)
 	}
 
 	JSBool allowInterrupt = NO;
-	if (JS_GetProperty(context, params, "allowInterrupt", &value) && !JSVAL_IS_VOID(value))
+	// force the allowInterrupt to be YES while in flight
+	if ([player status] == STATUS_IN_FLIGHT) 
 	{
-		JS_ValueToBoolean(context, value, &allowInterrupt);
+		allowInterrupt = YES;
+	} 
+	else
+	{
+		if (JS_GetProperty(context, params, "allowInterrupt", &value) && !JSVAL_IS_VOID(value))
+		{
+			JS_ValueToBoolean(context, value, &allowInterrupt);
+		}
 	}
 
 	if (JS_GetProperty(context, params, "exitScreen", &value) && !JSVAL_IS_VOID(value))


### PR DESCRIPTION
(resubmitted because I messed up the rebase)

One of the problems that has developed over time is the confusing list of F4 Interface screens that are added by OXP's. It doesn't take long for the list to become long and unwieldy.

The problem is that the F4 page is the only place to put a mission screen page. Even if the mission page is specifically related to the market, or the chart, or the system info view, they all have to go on the F4 page with some basic grouping as the only way to arrange things.

Coupled with this is the usefulness some of the pages have beyond the station. It makes sense to be able to view chart related info, or market info, as provided by an OXP, while in flight. The message has always been "do not show mission screens in flight," but that logic is counter to the fact that we can view the status screen, the manifest screen, do all sorts of interactions on the chart screen, view the market info page, all while in flight.

This PR aims to address both these issues. First, a new global function has been added, "setExtraGuiScreenKeys", which allows key functions to be registered on a specific gui screen. So, for example, the "Ctrl-G" key combination could be registered on the F6 chart screen. When the key combination is pressed on that screen, the callback function is called, similar to how the callback function is called for an F4 interfaces page. Each key combination defined in the properties is given a reference key, which will be passed to the callback function to identify what key combination was pressed.

By being able to link a mission screen to a specific GUI screen, some of the clutter on the F4 screen can be reduced.

Secondly, the warning message about showing mission screens in flight has been removed. Along with this, the "allowInterrupt" flag is defaulted to YES in all cases when in flight, which prevents a mission screen from locking the player out of their viewscreen. Ship models are already ignored in flight, and the exit screen will default to the main view.

The following is an example of setting up a new definition:
```
setExtraGuiScreenKeys(this.name, {
    guiScreen:"GUI_SCREEN_MANIFEST",
    registerKeys:{"key1":[{key:"g",mod1:true}]},
    callback:this.$myGuiScreenCallback.bind(this)
});
```
The format of the method is similar to the station.setInterface method. The key ("this.name" in the above example) can be registered once per GUI_SCREEN. Multiple key combinations can be specified in the "registerKeys" property. Using the same key and GUI_SCREEN will overwrite the previous settings.

There is also a method to remove the extra key definition:
```
clearExtraGuiScreenKeys(this.name, "GUI_SCREEN_MANIFEST");
```

This small OXP (an update to the RegisterKeysDemo1 used previously), demonstrates implementing the system: [RegisterKeysDemo1_v2.oxp.zip](https://app.box.com/s/z0y9x6f0y22go2o12o0z25oelkmmqbwc)