### PR TITLE
Fix for possible memory leak on Mac

### DIFF
--- a/src/Core/OOALSoundChannel.m
+++ b/src/Core/OOALSoundChannel.m
@@ -184,7 +184,7 @@ SOFTWARE.
 	if (_sound != nil)
 	{
 		OOAL(alSourceStop(_source));
-
+		OOAL(alSourcei(_source, AL_BUFFER, AL_NONE));
 		[self hasStopped];
 	}
 }


### PR DESCRIPTION
This is a fix for a possible memory leak on the Mac based on the info here: [https://blog.vucica.net/2011/06/avoiding-memory-leak-in-openal-and-crash-in-openal-for-mac.html](url)

I've been running this change in my local build (Windows) for a while without impact. But it would be good to hear from others (on Linux particularly) to make sure there is no obvious issues there before merging.

It may not be a fix for the issue with sounds on Mac, but it might help.