### PR TITLE
Witchjump js enhancements

### DIFF
--- a/src/Core/Entities/PlayerEntity.h
+++ b/src/Core/Entities/PlayerEntity.h
@@ -370,7 +370,8 @@ typedef enum
 	OOSystemID				system_id;
 	OOSystemID				target_system_id;
 	OOSystemID				info_system_id;
-
+	OOSystemID				previous_system_id;
+	
 	float					occlusion_dial;
 	
 	OOSystemID				found_system_id;
@@ -510,6 +511,9 @@ typedef enum
 	OORouteType				ANA_mode;
 	OOTimeDelta				witchspaceCountdown;
 	
+	NSString				*_jumpCause;
+	OOSystemID				previousSystem;
+
 	// player commander data
 	NSString				*_commanderName;
 	NSString				*_lastsaveName;
@@ -857,11 +861,15 @@ typedef enum
 - (NSPoint) adjusted_chart_centre;
 - (OORouteType) ANAMode;
 
+- (NSString *) jumpCause;
+- (void) setJumpCause:(NSString *)value;
 
 - (OOSystemID) systemID;
 - (void) setSystemID:(OOSystemID) sid;
 - (OOSystemID) targetSystemID;
 - (void) setTargetSystemID:(OOSystemID) sid;
+- (OOSystemID) previousSystemID;
+- (void) setPreviousSystemID:(OOSystemID) sid;
 - (OOSystemID) nextHopTargetSystemID;
 - (OOSystemID) infoSystemID;
 - (void) setInfoSystemID: (OOSystemID) sid moveChart:(BOOL) moveChart;

--- a/src/Core/Entities/PlayerEntity.h
+++ b/src/Core/Entities/PlayerEntity.h
@@ -512,7 +512,6 @@ typedef enum
 	OOTimeDelta				witchspaceCountdown;
 	
 	NSString				*_jumpCause;
-	OOSystemID				previousSystem;
 
 	// player commander data
 	NSString				*_commanderName;

--- a/src/Core/Scripting/OOJSPlayerShip.m
+++ b/src/Core/Scripting/OOJSPlayerShip.m
@@ -160,6 +160,7 @@ enum
 	kPlayerShip_targetSystem,					// target system id, int, read-write
 	kPlayerShip_nextSystem,						// next hop system id, read-only
 	kPlayerShip_infoSystem,						// info (F7 screen) system id, int, read-write
+	kPlayerShip_previousSystem,					// previous system id, read-only
 	kPlayerShip_torusEngaged,					// torus in use, boolean, read-only
 	kPlayerShip_viewDirection,					// view direction identifier, string, read-only
 	kPlayerShip_viewPositionAft,					// view position offset, vector, read-only
@@ -230,6 +231,7 @@ static JSPropertySpec sPlayerShipProperties[] =
 	{ "targetSystem",					kPlayerShip_targetSystem,					OOJS_PROP_READWRITE_CB },
 	{ "nextSystem",                     kPlayerShip_nextSystem,                     OOJS_PROP_READONLY_CB },
 	{ "infoSystem",						kPlayerShip_infoSystem,						OOJS_PROP_READWRITE_CB },
+	{ "previousSystem",					kPlayerShip_previousSystem,					OOJS_PROP_READONLY_CB },
 	{ "torusEngaged",					kPlayerShip_torusEngaged,					OOJS_PROP_READONLY_CB },
 	{ "viewDirection",					kPlayerShip_viewDirection,					OOJS_PROP_READONLY_CB },
 	{ "viewPositionAft",				kPlayerShip_viewPositionAft,				OOJS_PROP_READONLY_CB },
@@ -477,6 +479,10 @@ static JSBool PlayerShipGetProperty(JSContext *context, JSObject *this, jsid pro
 			*value = INT_TO_JSVAL([player infoSystemID]);
 			return YES;
 
+		case kPlayerShip_previousSystem:
+			*value = INT_TO_JSVAL([player previousSystemID]);
+			return YES;
+			
 		case kPlayerShip_routeMode:
 		{
 			OORouteType route = [player ANAMode];

--- a/src/Core/Universe.m
+++ b/src/Core/Universe.m
@@ -1032,9 +1032,12 @@ static GLfloat	docked_light_specular[4]	= { DOCKED_ILLUM_LEVEL, DOCKED_ILLUM_LEV
 
 		[player setWormhole:wormhole];
 		[player addScannedWormhole:wormhole];
-
-		ShipScriptEventNoCx(player, "shipWillEnterWitchspace", OOJSSTR("carried"), INT_TO_JSVAL(dest));
-		
+		JSContext *context = OOJSAcquireContext();
+		[player setJumpCause:@"carried"];
+		[player setPreviousSystemID:[player systemID]];
+		ShipScriptEvent(context, player, "shipWillEnterWitchspace", STRING_TO_JSVAL(JS_InternString(context, [[player jumpCause] UTF8String])), INT_TO_JSVAL(dest));
+		OOJSRelinquishContext(context);
+	
 		[self allShipsDoScriptEvent:OOJSID("playerWillEnterWitchspace") andReactToAIMessage:@"PLAYER WITCHSPACE"];
 
 		[player setRandom_factor:(ranrot_rand() & 255)];						// random factor for market values is reset
@@ -1076,8 +1079,8 @@ static GLfloat	docked_light_specular[4]	= { DOCKED_ILLUM_LEVEL, DOCKED_ILLUM_LEV
 											 alpha:0.0f];
 
 		[self setWitchspaceBreakPattern:YES];
-		[player doScriptEvent:OOJSID("shipWillExitWitchspace")];
-		[player doScriptEvent:OOJSID("shipExitedWitchspace")];
+		[player doScriptEvent:OOJSID("shipWillExitWitchspace") withArgument:[player jumpCause]];
+		[player doScriptEvent:OOJSID("shipExitedWitchspace") withArgument:[player jumpCause]];
 		[player setWormhole:nil];
 
 }
@@ -1095,7 +1098,8 @@ static GLfloat	docked_light_specular[4]	= { DOCKED_ILLUM_LEVEL, DOCKED_ILLUM_LEV
 		// check the nearest system
 		OOSystemID sys = [self findSystemNumberAtCoords:coords withGalaxy:[player galaxyNumber] includingHidden:YES];
 		BOOL interstel =[dockedStation interstellarUndockingAllowed];// && (s_seed.d != coords.x || s_seed.b != coords.y); - Nikos 20110623: Do we really need the commented out check?
-		
+		[player setPreviousSystemID:[player currentSystemID]];
+
 		// remove everything except the player and the docked station
 		if (dockedStation && !interstel)
 		{	// jump to the nearest system
@@ -1148,8 +1152,9 @@ static GLfloat	docked_light_specular[4]	= { DOCKED_ILLUM_LEVEL, DOCKED_ILLUM_LEV
 					[dockedStation setPosition: pos];
 				}
 				[self setWitchspaceBreakPattern:YES];
-				[player doScriptEvent:OOJSID("shipWillExitWitchspace")];
-				[player doScriptEvent:OOJSID("shipExitedWitchspace")];
+				[player setJumpCause:@"carried"];
+				[player doScriptEvent:OOJSID("shipWillExitWitchspace") withArgument:[player jumpCause]];
+				[player doScriptEvent:OOJSID("shipExitedWitchspace") withArgument:[player jumpCause]];
 			}
 		}
 	}


### PR DESCRIPTION
This PR is a QOL enhancement for witch space jumps. It adds the jump cause to all jump events, so each event can know what type of jump was performed. It also adds a new property to the player ship, "previousSystem", which holds the originating system ID from where the player has come. It will be in the range of -1 to 255.

On a programming note, I'm not happy with these lines:
`
ShipScriptEvent(context, self, "shipWillEnterWitchspace", STRING_TO_JSVAL(JS_InternString(context, [[self jumpCause] UTF8String])), INT_TO_JSVAL([w_hole destination]));
`

Something feels off with the number of conversions I'm doing to pass the jump cause to the STRING_TO_JSVAL function. If there's a better way, please let me know! Ideally I'd like to return to the "NoCx" version of "ShipScriptEvent" (and therefore removing the requirement to grab the context), so if there's a way to do that as well, I'm all ears!