### PR TITLE
Expands ship.canAwardEquipment for other contexts

### DIFF
--- a/src/Core/Entities/ShipEntity.m
+++ b/src/Core/Entities/ShipEntity.m
@@ -9334,7 +9334,9 @@ NSComparisonResult ComparePlanetsBySurfaceDistance(id i1, id i2, void* context)
 								{
 									[rock setScanClass: CLASS_CARGO];
 									[rock setBounty: 0 withReason:kOOLegalStatusReasonSetup];
-									[rock setCommodity:@"minerals" andAmount: 1];
+									// only make the rock have minerals if something isn't already defined for the rock
+									if ([[rock shipInfoDictionary] oo_stringForKey:@"cargo_carried"] == nil)
+										[rock setCommodity:@"minerals" andAmount: 1];
 								}
 								else
 								{


### PR DESCRIPTION
By default, the "canAwardEquipment" checks the equipment with the "scripted" context. This PR allows other contexts to be tested on an equipment item. 

For example:
`player.ship.canAwardEquipment("EQ_NAVAL_ENERGY_UNIT")` will return true. This is because, with the "scripted" context, it is allowed to be awarded to the player. However, there are restrictions on whether you can purchase the equipment or not. With this PR, you can do the following:
`player.ship.canAwardEquipment("EQ_NAVAL_ENERGY_UNIT", "purchase")`, which will return false if the player has not yet completed the mission it relates to.