### PR TITLE
Expanding ship.canAwardEquipment to allow other contexts

### DIFF
--- a/src/Core/Scripting/OOJSShip.m
+++ b/src/Core/Scripting/OOJSShip.m
@@ -2569,6 +2569,7 @@ static JSBool ShipCanAwardEquipment(JSContext *context, uintN argc, jsval *vp)
 	
 	ShipEntity					*thisEnt = nil;
 	NSString					*key = nil;
+	NSString					*ctx = @"scripted";
 	BOOL						result;
 	BOOL						exists;
 	
@@ -2583,12 +2584,21 @@ static JSBool ShipCanAwardEquipment(JSContext *context, uintN argc, jsval *vp)
 	
 	if (exists)
 	{
+		if (argc > 1)
+		{
+			ctx = OOStringFromJSValue(context, OOJS_ARGV[1]);
+			if (![ctx isEqualToString:@"scripted"] && ![ctx isEqualToString:@"purchase"] && ![ctx isEqualToString:@"newShip"] && ![ctx isEqualToString:@"npc"])
+			{
+				OOJSReportBadArguments(context, @"Ship", @"canAwardEquipment", MIN(argc, 2U), OOJS_ARGV, nil, @"context");
+				return NO;
+			}
+		}
 		result = YES;
 		
 		// can't add fuel as equipment.
 		if ([key isEqualToString:@"EQ_FUEL"])  result = NO;
 		
-		if (result)  result = [thisEnt canAddEquipment:key inContext:@"scripted"];
+		if (result)  result = [thisEnt canAddEquipment:key inContext:ctx];
 	}
 	else
 	{


### PR DESCRIPTION
For real, this time!

By default, the "canAwardEquipment" checks the equipment with the "scripted" context. This PR allows other contexts to be tested on an equipment item. 

For example:
`player.ship.canAwardEquipment("EQ_NAVAL_ENERGY_UNIT")` will return true. This is because, with the "scripted" context, it is allowed to be awarded to the player. However, there are restrictions on whether you can purchase the equipment or not. With this PR, you can do the following:
`player.ship.canAwardEquipment("EQ_NAVAL_ENERGY_UNIT", "purchase")`, which will return false if the player has not yet completed the mission it relates to.