### PR TITLE
Splinters that have cargo_carried defined will use that on spawn

### DIFF
--- a/src/Core/Entities/ShipEntity.m
+++ b/src/Core/Entities/ShipEntity.m
@@ -9334,7 +9334,9 @@ NSComparisonResult ComparePlanetsBySurfaceDistance(id i1, id i2, void* context)
 								{
 									[rock setScanClass: CLASS_CARGO];
 									[rock setBounty: 0 withReason:kOOLegalStatusReasonSetup];
-									[rock setCommodity:@"minerals" andAmount: 1];
+									// only make the rock have minerals if something isn't already defined for the rock
+									if ([[rock shipInfoDictionary] oo_stringForKey:@"cargo_carried"] == nil)
+										[rock setCommodity:@"minerals" andAmount: 1];
 								}
 								else
 								{


### PR DESCRIPTION
Currently, regardless of what a splinter might have defined, it will always be given minerals when it is spawned from mining a boulder. This patch will check for the "cargo_carried" property in shipdata, and if found, will allow it to define the makeup of the splinter. If no "cargo_carried" property is defined, the default behaviour will apply.