### PR TITLE
use full version info on asset

### DIFF
--- a/installers/posix/make_installer.sh
+++ b/installers/posix/make_installer.sh
@@ -40,7 +40,7 @@ oolite_version_extended=$2
 githash=`echo $oolite_version_extended | cut -d '-' -f 3`
 if [ "$build_submode" = "snapshot" ]
 then
-  oolite_version=`echo $oolite_version_extended | awk -F"\." '{print $1"."$2"."$3"."}'`$githash
+  oolite_version=$oolite_version_extended
   if [ "$4" = "nightly" ]
   then
     # trunk="-trunk"
@@ -48,7 +48,7 @@ then
     noxterm="--nox11"   # If nightly, do NOT spawn an x11 terminal when installer is started from desktop
   fi    
 else
-  oolite_version=`echo $oolite_version_extended | awk -F"\." '{print $1"."$2"."$3"."}'`$githash
+  oolite_version=$oolite_version_extended
   ver_rev=`echo $oolite_version_extended | cut -d '.' -f 3`
   
   if [ "$build_submode" = "test" ]

--- a/installers/win32/OOlite.nsi
+++ b/installers/win32/OOlite.nsi
@@ -58,7 +58,7 @@ SetCompress auto
 SetCompressor LZMA
 SetCompressorDictSize 32
 SetDatablockOptimize on
-OutFile "${OUTDIR}\OoliteInstall-${VER_MAJ}.${VER_MIN}.${VER_REV}.${VER_GITHASH}-win${EXTVER}.exe"
+OutFile "${OUTDIR}\OoliteInstall-${VER}-win${EXTVER}.exe"
 BrandingText "(C) 2003-2022 Giles Williams, Jens Ayton and contributors"
 Name "Oolite"
 Caption "Oolite ${VER}${EXTVER} Setup"


### PR DESCRIPTION
Now we can drop all deliverables in a single directory and still figure out which is which in correct sequence.