### PR TITLE
Hostile lollipops in colorblind mode

### DIFF
--- a/Doc/CHANGELOG.TXT
+++ b/Doc/CHANGELOG.TXT
@@ -13,6 +13,9 @@ General:
   screen to be displayed.
 * Added new visual effect when cloaked.
 * Added colourblind support, available in game options screen.
+* In colorblind mode, scanner blips of hostile ships are now drawn as X
+  shapes instead of squares, to ensure easier recognition and enhance
+  accessibility.
 * Full keyboard configuration now available in game.
 * In-game handling of non-US keyboard layouts.
 * Added ability to assign any key or joystick button to the "activate" or 

--- a/src/Core/HeadUpDisplay.m
+++ b/src/Core/HeadUpDisplay.m
@@ -1186,6 +1186,8 @@ static void prefetchData(NSDictionary *info, struct CachedInfo *data)
 	BOOL			emptyDial = ([info oo_floatForKey:ALPHA_KEY] == 0.0f);
 		
 	BOOL			isHostile = NO;
+
+ 	BOOL			inColorBlindMode = [UNIVERSE colorblindMode] != OO_POSTFX_NONE;
 	
 	if (emptyDial)
 	{

--- a/src/Core/HeadUpDisplay.m
+++ b/src/Core/HeadUpDisplay.m
@@ -1449,9 +1449,21 @@ static void prefetchData(NSDictionary *info, struct CachedInfo *data)
 						OODrawString([(ShipEntity *)scannedEntity displayName], x1 + 2, y2 + 2, z1, NSMakeSize(8, 8));
 					}
 #endif
-					OOGLBEGIN(GL_QUADS);
-						glColor4fv(col);
+					glColor4fv(col);
+					if (inColorBlindMode && isHostile)
+					{
+						// in colorblind mode turn hostile blips into X shapes for easier recognition
+						OOGLBEGIN(GL_LINES);
+						glVertex3f(x1+2, y2+3, z1);	glVertex3f(x1-3, y2, z1);	glVertex3f(x1+2, y2, z1);	glVertex3f(x1-3, y2+3, z1);
+						OOGLEND();
+					}
+					else
+					{
+						OOGLBEGIN(GL_QUADS);
 						glVertex3f(x1-3, y2, z1);	glVertex3f(x1+2, y2, z1);	glVertex3f(x1+2, y2+3, z1);	glVertex3f(x1-3, y2+3, z1);	
+						OOGLEND();
+					}
+					OOGLBEGIN(GL_QUADS); // lollipop tail
 						col[3] *= 0.3333; // one third the alpha
 						glColor4fv(col);
 						glVertex3f(x1, y1, z1);	glVertex3f(x1+2, y1, z1);	glVertex3f(x1+2, y2, z1);	glVertex3f(x1, y2, z1);


### PR DESCRIPTION
This is an accessibility oriented pull request. The idea is to make hostile ships on the scanner more easily distinguishable for colorblind people.

The colorblind mode algorithms we have enhance contrast of displayed colors to make them easily distinguishable as different. Still, sometimes when there is a lot going on in the screen, some additional visual clues would be good for persons who have trouble distinguishing key colors, even if we modify the contrast to make it easier for them. With this PR, in addition to the colorblind filters in use, we change the lollipop blips of hostile ships to an X instead of a square. This way, it only takes one quick look on the scanner and all hostiles can be easily identified.

This is something I had wanted to add for a long time now and is also consistent with color blindness accessibility best practices (don't just change the color, change the shape of key game elements as well if you can).