### PR TITLE
Allows for consistent naming of fields in the equipment-overrides.pli…

### DIFF
--- a/Doc/CHANGELOG.TXT
+++ b/Doc/CHANGELOG.TXT
@@ -56,6 +56,9 @@ Modified Plists:
 * planetinfo.plist: illumination_color added (used with illumination map in planet
   texture).
 * planetinfo.plist: added air_density (default value 0.75).
+* "name" and "description" properties are now available for use in 
+  equipment-overrides.plist, as optional replacements for "short_description" and
+  "long_description" respectively, so as to match EquipmentInfo specification.
 
 Scripting:
 ----------

--- a/src/Core/ResourceManager.m
+++ b/src/Core/ResourceManager.m
@@ -1491,7 +1491,7 @@ static NSMutableDictionary *sStringCache;
 // handles processing of equipment-overrides.plist files, updating the source array with values found.
 // format of file is slightly different to the standard equipment.plist file, in that it is a 
 // dictionary of dictionary objects (rather than an array of arrays). this allows properties like
-// techlevel, price, short_description and long_description to be updated via the overrides file.
+// techlevel, price, name/short_description and description/long_description to be updated via the overrides file.
 + (void) handleEquipmentOverrides: (NSMutableArray *)arrayToProcess
 {
 	NSEnumerator			*equipKeyEnum = nil;
@@ -1529,7 +1529,11 @@ static NSMutableDictionary *sStringCache;
 						[equipArray replaceObjectAtIndex:EQUIPMENT_PRICE_INDEX withObject:[overridesEntry objectForKey:infoKey]];
 					else if ([infoKey isEqualToString:@"short_description"]) 
 						[equipArray replaceObjectAtIndex:EQUIPMENT_SHORT_DESC_INDEX withObject:[overridesEntry objectForKey:infoKey]];
+					else if ([infoKey isEqualToString:@"name"]) 
+						[equipArray replaceObjectAtIndex:EQUIPMENT_SHORT_DESC_INDEX withObject:[overridesEntry objectForKey:infoKey]];
 					else if ([infoKey isEqualToString:@"long_description"]) 
+						[equipArray replaceObjectAtIndex:EQUIPMENT_LONG_DESC_INDEX withObject:[overridesEntry objectForKey:infoKey]];
+					else if ([infoKey isEqualToString:@"description"]) 
 						[equipArray replaceObjectAtIndex:EQUIPMENT_LONG_DESC_INDEX withObject:[overridesEntry objectForKey:infoKey]];
 					else 
 					{


### PR DESCRIPTION
…st file
When I added the original code, for some reason I just plain forgot that the "name" and "description" fields were already being used in the EquipmentInfo object, and would have made much more sense to reuse. This PR allows for those properties to be used in place of "short_description" and "long_description". I haven't removed the previous property names, so no OXP will break.