### PR TITLE
Hides the price and install time values on the F3 Ship Outfitting screen

### DIFF
--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -9566,7 +9566,16 @@ static NSString *last_outfitting_key=nil;
 				{
 					// Normal equipment list.
 					[gui setKey:eqKey forRow:row];
-					[gui setArray:[NSArray arrayWithObjects:desc, priceString, timeString, nil] forRow:row];
+					// check if the hidevalues property has been set
+					if (![eqInfo hideValues])
+					{
+						[gui setArray:[NSArray arrayWithObjects:desc, priceString, timeString, nil] forRow:row];
+					}
+					else
+					{
+						// if so, only output the description
+						[gui setArray:[NSArray arrayWithObjects:desc, nil] forRow:row];
+					}
 					row++;
 				}
 			}

--- a/src/Core/OOEquipmentType.h
+++ b/src/Core/OOEquipmentType.h
@@ -57,7 +57,8 @@ SOFTWARE.
 							_isAvailableToNPCs: 1,
 							_fastAffinityA: 1,
 							_fastAffinityB: 1,
-							_canCarryMultiple: 1;
+							_canCarryMultiple: 1,
+							_hideValues: 1;
 	OOColor					*_displayColor;
 	NSUInteger				_installTime;
 	NSUInteger				_repairTime;
@@ -111,6 +112,7 @@ SOFTWARE.
 - (GLfloat) damageProbability;
 - (BOOL) canBeDamaged;
 - (BOOL) isVisible;				// Visible in UI?
+- (BOOL) hideValues;
 - (OOColor *) displayColor;
 - (void) setDisplayColor:(OOColor *)newColor;
 

--- a/src/Core/OOEquipmentType.m
+++ b/src/Core/OOEquipmentType.m
@@ -202,6 +202,7 @@ static NSDictionary		*sMissilesRegistry = nil;
 		_isAvailableToPlayer = YES;
 		_isAvailableToNPCs = YES;
 		_damageProbability = 1.0;
+		_hideValues = NO;
 	}
 	
 	if (OK && [info count] > EQUIPMENT_EXTRA_INFO_INDEX)
@@ -226,7 +227,8 @@ static NSDictionary		*sMissilesRegistry = nil;
 			_requiresNonFullFuel = [extra oo_boolForKey:@"requires_non_full_fuel" defaultValue:_requiresNonFullFuel];
 			_isVisible = [extra oo_boolForKey:@"visible" defaultValue:_isVisible];
 			_canCarryMultiple = [extra oo_boolForKey:@"can_carry_multiple" defaultValue:NO];
-			
+			_hideValues = [extra oo_boolForKey:@"hide_values" defaultValue:NO];
+
 			_requiredCargoSpace = [extra oo_unsignedIntForKey:@"requires_cargo_space" defaultValue:_requiredCargoSpace];
 
 			_installTime = [extra oo_unsignedIntForKey:@"installation_time" defaultValue:0];
@@ -498,6 +500,12 @@ static NSDictionary		*sMissilesRegistry = nil;
 - (BOOL) isVisible
 {
 	return _isVisible;
+}
+
+
+- (BOOL) hideValues
+{
+	return _hideValues;
 }
 
 


### PR DESCRIPTION
This makes it possible to have more display options on the F3 screen (allowing header entries, or top-level entries).