### PR TITLE
Added player ship property to allow status screen equipment to have a…

### DIFF
--- a/Doc/CHANGELOG.TXT
+++ b/Doc/CHANGELOG.TXT
@@ -39,6 +39,8 @@ General:
 * Improved sun rendering.
 * Implemented user-defined planet dark-side illumination color, when an
   illumination map is in use.
+* Added "statusScreenEquipmentSortMode" to switch the ordering of equipment
+  between the default reverse order and ascending order.
 * Added an "update all" option to the Expansion Pack Manager.
 * Updated atmosphere density rendering.
 * Added game paused message to game options when in flight.
@@ -76,6 +78,8 @@ Scripting:
 * Added planet.airDensity property.
 * Added Ship.setShipInfoForKey to allow for shipdata updates during the game.
 * Added equipment.weaponInfo dictionary.
+* Added player.ship.statusScreenEquipmentSortMode read/write property. 0 = default,
+  (reverse), 1 = ascending.
 
 Bug Fixes:
 ==========

--- a/src/Core/Entities/PlayerEntity.h
+++ b/src/Core/Entities/PlayerEntity.h
@@ -292,6 +292,13 @@ typedef enum
 } OOMarketSorterMode;
 
 
+typedef enum
+{
+	STATUS_EQUIP_SORT_DEFAULT = 0,
+	STATUS_EQUIP_SORT_ASC = 1
+} OOStatusEquipSorterMode;
+
+
 #define ECM_ENERGY_DRAIN_FACTOR			20.0f
 #define ECM_DURATION					2.5f
 
@@ -459,6 +466,8 @@ typedef enum
 
 	OOWeakReference			*_dockedStation;
 	
+	OOStatusEquipSorterMode	statusEquipSorterMode;
+
 /* Used by the DOCKING_CLEARANCE code to implement docking at non-main
  * stations. Could possibly overload use of 'dockedStation' instead
  * but that needs futher investigation to ensure it doesn't break anything. */
@@ -1084,6 +1093,8 @@ typedef enum
 
 - (void) setGuiToStatusScreen;
 - (NSArray *) equipmentList;	// Each entry is an array with a string followed by a boolean indicating availability (NO = damaged), then a color (or nil for default color).
+- (OOStatusEquipSorterMode) statusScreenEquipmentSortMode;
+- (void) setStatusScreenEquipmentSortMode:(NSInteger)mode;
 - (BOOL) setPrimedEquipment:(NSString *)eqKey showMessage:(BOOL)showMsg;
 - (NSString *) primedEquipmentName:(NSInteger)offset;
 - (NSString *) currentPrimedEquipment;

--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -2126,7 +2126,8 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 	
 	max_cargo				= 20; // will be reset later
 	marketFilterMode		= MARKET_FILTER_MODE_OFF;
-	
+	statusEquipSorterMode	= STATUS_EQUIP_SORT_DEFAULT;
+
 	DESTROY(shipCommodityData);
 	shipCommodityData = [[[UNIVERSE commodities] generateManifestForPlayer] retain];
 	
@@ -8046,7 +8047,17 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 
 	BOOL prioritiseDamaged = [[gui userSettings] oo_boolForKey:kGuiStatusPrioritiseDamaged defaultValue:YES];
 
-	for (eqTypeEnum = [OOEquipmentType reverseEquipmentEnumerator]; (eqType = [eqTypeEnum nextObject]); )
+	/*
+		The default sort method (reverse) is intended to get the most important equipment on the first page of the F5 Status screen.
+		The assumption is, higher TL and higher Price, must be more more important. Anything with a sort_order is prioritised over
+		and above the TL+price sort. 
+		However, once a sort_order has been applied to a lot of equipment items, reverse sort starts to become a problem, as any 
+		ordering that is incorporated into the sort_order is reversed as well. 
+		To work around this, a normal (forward) sorting method can now be specified.
+	*/
+	BOOL sort = (statusEquipSorterMode != STATUS_EQUIP_SORT_DEFAULT);
+
+	for (eqTypeEnum = (sort ? [OOEquipmentType equipmentEnumerator] : [OOEquipmentType reverseEquipmentEnumerator]); (eqType = [eqTypeEnum nextObject]); )
 	{
 		if ([eqType isVisible])
 		{
@@ -8159,6 +8170,25 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 	// list damaged first, then working
 	[quip1 addObjectsFromArray:quip2];
 	return quip1;
+}
+
+
+- (OOStatusEquipSorterMode) statusScreenEquipmentSortMode
+{
+	return statusEquipSorterMode;
+}
+
+- (void) setStatusScreenEquipmentSortMode:(NSInteger)mode
+{
+	switch (mode)
+	{
+		case 0:
+			statusEquipSorterMode = STATUS_EQUIP_SORT_DEFAULT;
+			break;
+		case 1:
+			statusEquipSorterMode = STATUS_EQUIP_SORT_ASC;
+			break;
+	}
 }
 
 

--- a/src/Core/Scripting/OOJSPlayerShip.m
+++ b/src/Core/Scripting/OOJSPlayerShip.m
@@ -157,6 +157,7 @@ enum
 	kPlayerShip_scoopOverride,					// Scooping
 	kPlayerShip_serviceLevel,					// servicing level, positive int 75-100, read-only
 	kPlayerShip_specialCargo,					// special cargo, string, read-only
+	kPlayerShip_statusScreenEquipmentSort,		// status screen equipment sort direction, read-write
 	kPlayerShip_targetSystem,					// target system id, int, read-write
 	kPlayerShip_nextSystem,						// next hop system id, read-only
 	kPlayerShip_infoSystem,						// info (F7 screen) system id, int, read-write
@@ -228,6 +229,7 @@ static JSPropertySpec sPlayerShipProperties[] =
 	{ "scoopOverride",					kPlayerShip_scoopOverride,					OOJS_PROP_READWRITE_CB },
 	{ "serviceLevel",					kPlayerShip_serviceLevel,					OOJS_PROP_READWRITE_CB },
 	{ "specialCargo",					kPlayerShip_specialCargo,					OOJS_PROP_READONLY_CB },
+	{ "statusScreenEquipmentSort",		kPlayerShip_statusScreenEquipmentSort,		OOJS_PROP_READWRITE_CB },
 	{ "targetSystem",					kPlayerShip_targetSystem,					OOJS_PROP_READWRITE_CB },
 	{ "nextSystem",                     kPlayerShip_nextSystem,                     OOJS_PROP_READONLY_CB },
 	{ "infoSystem",						kPlayerShip_infoSystem,						OOJS_PROP_READWRITE_CB },
@@ -581,7 +583,11 @@ static JSBool PlayerShipGetProperty(JSContext *context, JSObject *this, jsid pro
 		case kPlayerShip_currentWeapon:
 			result = [player weaponTypeForFacing:[player currentWeaponFacing] strict:NO];
 			break;
-		
+
+		case kPlayerShip_statusScreenEquipmentSort:
+			*value = INT_TO_JSVAL([player statusScreenEquipmentSortMode]);
+			return YES;
+
 	  case kPlayerShip_price:
 			return JS_NewNumberValue(context, [UNIVERSE tradeInValueForCommanderDictionary:[player commanderDataDictionary]], value);
 
@@ -778,7 +784,22 @@ static JSBool PlayerShipSetProperty(JSContext *context, JSObject *this, jsid pro
 				return YES;
 			}
 			break;
-			
+
+		case kPlayerShip_statusScreenEquipmentSort:
+			if (JS_ValueToInt32(context, *value, &iValue))
+			{
+				if (iValue >= 0 && iValue <= 1)
+				{ 
+					[player setStatusScreenEquipmentSortMode:iValue];
+					return YES;
+				}
+				else
+				{
+					return NO;
+				}
+			}
+			break;
+
 		case kPlayerShip_fastEquipmentA:
 			sValue = OOStringFromJSValue(context, *value);
 			if (sValue != nil)


### PR DESCRIPTION
…scending sort
The default sort method works to put the most important equipment on the first page of the F5 Status screen. The assumption is, if it's got a high TL and price, it must be more important. The sort_order property of equipment is considered before these two. However, because the list is in reverse order, any ordering that has been encoded into the "sort_order" property will also be reversed.
To work around this, a new r/w property has been added to the player.ship: "statusScreenEquipmentSort". The default value for this is 0, which is the reverse order method, as it currently works. By changing this value to 1, the list goes back to an ascending order, which gives OXP's that make heavy use of the "sort_order" property the opportunity to decide what order should be used on the status screen.