### PR TITLE
Adds purchase_sort_order to equipment.plist to sort F3 screen indepen…

### DIFF
--- a/Doc/CHANGELOG.TXT
+++ b/Doc/CHANGELOG.TXT
@@ -63,6 +63,8 @@ Modified Plists:
   EquipmentInfo specification.
 * equipment.plist: hide_values allows an equipment item to hide the cost and 
   install time values on the F3 Ship Outfitting screen.
+* equipment.plist: purchase_sort_order allows the sorting of the F3 Ship Outfitting
+  screen to be sorted independently of the F5 Status screen.
 
 Scripting:
 ----------

--- a/Resources/Config/equipment.plist
+++ b/Resources/Config/equipment.plist
@@ -7,7 +7,7 @@
 			available_to_all = true;
 			condition_script = "oolite-conditions.js";
 			requires_non_full_fuel = true;
-			sort_order = 1; // always first
+			purchase_sort_order = 1; // always first
 		}
 	),
 	(

--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -9320,7 +9320,7 @@ static NSString *last_outfitting_key=nil;
 		[equipmentAllowed addObject:eqKeyForSelectFacing];
 		[equipmentAllowed addObject:eqKeyForSelectFacing];
 	}
-	else for (eqEnum = [OOEquipmentType equipmentEnumerator]; (eqType = [eqEnum nextObject]); i++)
+	else for (eqEnum = [OOEquipmentType equipmentEnumeratorOutfitting]; (eqType = [eqEnum nextObject]); i++)
 	{
 		NSString			*eqKey = [eqType identifier];
 		OOTechLevelID		minTechLevel = [eqType effectiveTechLevel];

--- a/src/Core/OOEquipmentType.h
+++ b/src/Core/OOEquipmentType.h
@@ -86,6 +86,7 @@ SOFTWARE.
 + (NSArray *) allEquipmentTypes;
 + (NSEnumerator *) equipmentEnumerator;
 + (NSEnumerator *) reverseEquipmentEnumerator;
++ (NSEnumerator *) equipmentEnumeratorOutfitting;
 
 + (OOEquipmentType *) equipmentTypeWithIdentifier:(NSString *)identifier;
 

--- a/src/Core/OOEquipmentType.m
+++ b/src/Core/OOEquipmentType.m
@@ -34,6 +34,7 @@ SOFTWARE.
 
 
 static NSArray			*sEquipmentTypes = nil;
+static NSArray			*sEquipmentTypesOutfitting = nil;
 static NSDictionary		*sEquipmentTypesByIdentifier = nil;
 static NSDictionary		*sMissilesRegistry = nil;
 
@@ -88,23 +89,47 @@ static NSDictionary		*sMissilesRegistry = nil;
 
 	sEquipmentTypes = [equipmentTypes copy];
 	sEquipmentTypesByIdentifier = [[NSDictionary alloc] initWithDictionary:equipmentTypesByIdentifier];
+
+	// same for the outfitting dataset
+	equipmentData = [UNIVERSE equipmentDataOutfitting];
+
+	[sEquipmentTypesOutfitting release];
+	sEquipmentTypesOutfitting = nil;
+
+	equipmentTypes = [NSMutableArray arrayWithCapacity:[equipmentData count]];
+	for (itemEnum = [equipmentData objectEnumerator]; (itemInfo = [itemEnum nextObject]); )
+	{
+		item = [[[OOEquipmentType alloc] initWithInfo:itemInfo] autorelease];
+		if (item != nil)
+		{
+			[equipmentTypes addObject:item];
+			[equipmentTypesByIdentifier setObject:item forKey:[item identifier]];
+		}
+	}
+	sEquipmentTypesOutfitting = [equipmentTypes copy];
+
 }
 
 
 + (void) addEquipmentWithInfo:(NSArray *)itemInfo
 {
 	NSMutableArray		*equipmentTypes = [NSMutableArray arrayWithArray:sEquipmentTypes];
+	NSMutableArray		*equipmentTypesOutfitting = [NSMutableArray arrayWithArray:sEquipmentTypesOutfitting];
 	NSMutableDictionary	*equipmentTypesByIdentifier = [[NSMutableDictionary alloc] initWithDictionary:sEquipmentTypesByIdentifier];
 	OOEquipmentType		*item = [[[OOEquipmentType alloc] initWithInfo:itemInfo] autorelease];
 	if (item != nil)
 	{
 		[equipmentTypes addObject:item];
+		[equipmentTypesOutfitting addObject:item];
 		[equipmentTypesByIdentifier setObject:item forKey:[item identifier]];
 		
 		[sEquipmentTypes release];
 		sEquipmentTypes = nil;
+		[sEquipmentTypesOutfitting release];
+		sEquipmentTypesOutfitting = nil;	
 		DESTROY(sEquipmentTypesByIdentifier);
 		sEquipmentTypes = [equipmentTypes copy];
+		sEquipmentTypesOutfitting = [equipmentTypesOutfitting copy];
 		sEquipmentTypesByIdentifier = [[NSDictionary alloc] initWithDictionary:equipmentTypesByIdentifier];
 	}
 	DESTROY(equipmentTypesByIdentifier);
@@ -145,6 +170,12 @@ static NSDictionary		*sMissilesRegistry = nil;
 + (NSEnumerator *) reverseEquipmentEnumerator
 {
 	return [sEquipmentTypes reverseObjectEnumerator];
+}
+
+
++ (NSEnumerator *) equipmentEnumeratorOutfitting
+{
+	return [sEquipmentTypesOutfitting objectEnumerator];
 }
 
 

--- a/src/Core/Universe.h
+++ b/src/Core/Universe.h
@@ -271,6 +271,7 @@ enum
 	OOSystemDescriptionManager	*systemManager; // planetinfo data manager
 	NSDictionary			*missiontext;			// holds descriptive text for missions, loaded at initialisation
 	NSArray					*equipmentData;			// holds data on available equipment, loaded at initialisation
+	NSArray					*equipmentDataOutfitting;
 //	NSSet					*pirateVictimRoles;		// Roles listed in pirateVictimRoles.plist.
 	NSDictionary			*roleCategories;		// Categories for roles from role-categories.plist, extending the old pirate-victim-roles.plist
 	NSDictionary			*autoAIMap;				// Default AIs for roles from autoAImap.plist.
@@ -710,6 +711,7 @@ enum
 - (NSDictionary *) globalSettings;
 
 - (NSArray *) equipmentData;
+- (NSArray *) equipmentDataOutfitting;
 - (OOCommodityMarket *) commodityMarket;
 - (Random_Seed) marketSeed;
 
@@ -840,6 +842,7 @@ OOINLINE Universe *OOGetUniverse(void)
 // Not for direct use.
 NSComparisonResult populatorPrioritySort(id a, id b, void *context);
 NSComparisonResult equipmentSort(id a, id b, void *context);
+NSComparisonResult equipmentSortOutfitting(id a, id b, void *context);
 NSString *OOLookUpDescriptionPRIV(NSString *key);
 NSString *OOLookUpPluralDescriptionPRIV(NSString *key, NSInteger count);
 

--- a/src/Core/Universe.m
+++ b/src/Core/Universe.m
@@ -863,6 +863,7 @@ static GLfloat	docked_light_specular[4]	= { DOCKED_ILLUM_LEVEL, DOCKED_ILLUM_LEV
 	[systemManager release];
 	[missiontext release];
 	[equipmentData release];
+	[equipmentDataOutfitting release];
 	[demo_ships release];
 	[autoAIMap release];
 	[screenBackgrounds release];
@@ -6975,7 +6976,7 @@ OOINLINE BOOL EntityInRange(HPVector p1, Entity *e2, float range)
 		}
 		
 		[self showGUIMessage:text withScroll:YES andColor:[message_gui textColor] overDuration:count];
-		
+				
 		[currentMessage release];
 		currentMessage = [text retain];
 		messageRepeatTime=universal_time + 6.0;
@@ -8854,6 +8855,12 @@ static void VerifyDesc(NSString *key, id desc)
 }
 
 
+- (NSArray *) equipmentDataOutfitting
+{
+	return equipmentDataOutfitting;
+}
+
+
 - (OOCommodityMarket *) commodityMarket
 {
 	return commodityMarket;
@@ -10326,8 +10333,10 @@ static OOComparisonResult comparePrice(id dict1, id dict2, void *context)
 	autoAIMap = [[ResourceManager dictionaryFromFilesNamed:@"autoAImap.plist" inFolder:@"Config" andMerge:YES] retain];
 	
 	[equipmentData autorelease];
+	[equipmentDataOutfitting autorelease];
 	NSArray *equipmentTemp = [ResourceManager arrayFromFilesNamed:@"equipment.plist" inFolder:@"Config" andMerge:YES];
 	equipmentData = [[equipmentTemp sortedArrayUsingFunction:equipmentSort context:NULL] retain];
+	equipmentDataOutfitting = [[equipmentTemp sortedArrayUsingFunction:equipmentSortOutfitting context:NULL] retain];
 	
 	[OOEquipmentType loadEquipment];
 
@@ -11083,6 +11092,32 @@ NSComparisonResult equipmentSort(id a, id b, void *context)
 
 	OOCreditsQuantity comp1 = [[one oo_dictionaryAtIndex:EQUIPMENT_EXTRA_INFO_INDEX] oo_unsignedLongLongForKey:@"sort_order" defaultValue:1000];
 	OOCreditsQuantity comp2 = [[two oo_dictionaryAtIndex:EQUIPMENT_EXTRA_INFO_INDEX] oo_unsignedLongLongForKey:@"sort_order" defaultValue:1000];
+	if (comp1 < comp2) return NSOrderedAscending;
+	if (comp1 > comp2) return NSOrderedDescending;
+
+	comp1 = [one oo_unsignedLongLongAtIndex:EQUIPMENT_TECH_LEVEL_INDEX];
+	comp2 = [two oo_unsignedLongLongAtIndex:EQUIPMENT_TECH_LEVEL_INDEX];
+	if (comp1 < comp2) return NSOrderedAscending;
+	if (comp1 > comp2) return NSOrderedDescending;
+
+	comp1 = [one oo_unsignedLongLongAtIndex:EQUIPMENT_PRICE_INDEX];
+	comp2 = [two oo_unsignedLongLongAtIndex:EQUIPMENT_PRICE_INDEX];
+	if (comp1 < comp2) return NSOrderedAscending;
+	if (comp1 > comp2) return NSOrderedDescending;
+
+	return NSOrderedSame;
+}
+
+
+NSComparisonResult equipmentSortOutfitting(id a, id b, void *context)
+{
+	NSArray *one = (NSArray *)a;
+	NSArray *two = (NSArray *)b;
+
+	/* Sort by explicit sort_order, then tech level, then price */
+
+	OOCreditsQuantity comp1 = [[one oo_dictionaryAtIndex:EQUIPMENT_EXTRA_INFO_INDEX] oo_unsignedLongLongForKey:@"purchase_sort_order" defaultValue:[[one oo_dictionaryAtIndex:EQUIPMENT_EXTRA_INFO_INDEX] oo_unsignedLongLongForKey:@"sort_order" defaultValue:1000]];
+	OOCreditsQuantity comp2 = [[two oo_dictionaryAtIndex:EQUIPMENT_EXTRA_INFO_INDEX] oo_unsignedLongLongForKey:@"purchase_sort_order" defaultValue:[[two oo_dictionaryAtIndex:EQUIPMENT_EXTRA_INFO_INDEX] oo_unsignedLongLongForKey:@"sort_order" defaultValue:1000]];
 	if (comp1 < comp2) return NSOrderedAscending;
 	if (comp1 > comp2) return NSOrderedDescending;
 


### PR DESCRIPTION
…dently of F5 screen
This is following a suggestion from @cim--  in #469 to keep the sorting on the F5 page in reverse order, and splitting the F3 sort to have it's own.
If "purchase_sort_order" is not supplied, "sort_order" will be used. In neither is supplied, 1000 will be used.
