### PR TITLE
Added ability to set default activate+mode keys for equipment items

### DIFF
--- a/Doc/CHANGELOG.TXT
+++ b/Doc/CHANGELOG.TXT
@@ -65,7 +65,10 @@ Modified Plists:
   install time values on the F3 Ship Outfitting screen.
 * equipment.plist: purchase_sort_order allows the sorting of the F3 Ship Outfitting
   screen to be sorted independently of the F5 Status screen.
-  
+* equipment.plist: default_activate_key and default_mode_key allows a default key
+  setting for the activate and mode keys. If, when loading, a conflict with another
+  key is encountered, the setting will be ignored.
+
 Scripting:
 ----------
 * Added world event consoleMessageReceived.
@@ -83,6 +86,9 @@ Scripting:
 * Added planet.airDensity property.
 * Added Ship.setShipInfoForKey to allow for shipdata updates during the game.
 * Added equipment.weaponInfo dictionary.
+* Added equipment.defaultActivateKey and equipment.defaultModeKey, each are 
+  read-only arrays of the default key settings for the equipment item. values
+  and null if the values haven't been defined.
 
 Bug Fixes:
 ==========

--- a/src/Core/Entities/PlayerEntity.h
+++ b/src/Core/Entities/PlayerEntity.h
@@ -987,6 +987,8 @@ typedef enum
 - (BOOL) injectorsEngaged;
 - (BOOL) hyperspeedEngaged;
 
+- (NSMutableArray *) customEquipmentActivation;
+
 
 - (double) clockTime;			// Note that this is not an OOTimeAbsolute
 - (double) clockTimeAdjusted;	// Note that this is not an OOTimeAbsolute

--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -11538,10 +11538,19 @@ static NSString *last_outfitting_key=nil;
 	return OK;
 }
 
+
+- (NSMutableArray *) customEquipmentActivation
+{
+	return customEquipActivation;
+}
+
+
 - (void) addEquipmentWithScriptToCustomKeyArray:(NSString *)equipmentKey
 {
 	NSDictionary *item;
 	NSUInteger i, j;
+	NSArray *object;
+
 	for (i = 0; i < [eqScripts count]; i++) 
 	{
 		if ([[[eqScripts oo_arrayAtIndex:i] oo_stringAtIndex:0] isEqualToString:equipmentKey]) 
@@ -11555,6 +11564,17 @@ static NSString *last_outfitting_key=nil;
 			// add the basic info at this point (equipkey and name only)
 			OOEquipmentType *eq = [OOEquipmentType equipmentTypeWithIdentifier:equipmentKey];
 			NSMutableDictionary *customKey = [[NSMutableDictionary alloc] initWithObjectsAndKeys:equipmentKey, CUSTOMEQUIP_EQUIPKEY, [eq name], CUSTOMEQUIP_EQUIPNAME, nil];
+			
+			// grab any default keys from the equipment item
+			// default activate
+			object = [eq defaultActivateKey];
+			if ((object != nil && [object count] > 0))
+				[customKey setObject:object forKey:CUSTOMEQUIP_KEYACTIVATE];
+			// default mode
+			object = [eq defaultModeKey];
+			if ((object != nil && [object count] > 0))
+				[customKey setObject:object forKey:CUSTOMEQUIP_KEYMODE];
+
 			[customEquipActivation addObject:customKey];
 			[customKey release];
 			// keep the keypress arrays in sync

--- a/src/Core/Entities/PlayerEntityKeyMapper.h
+++ b/src/Core/Entities/PlayerEntityKeyMapper.h
@@ -86,6 +86,8 @@ MA 02110-1301, USA.
    - (void) setGuiToKeyboardLayoutScreen:(unsigned)skip resetCurrentRow:(BOOL)resetCurrentRow;
    - (void) handleKeyboardLayoutEntryKeys:(GuiDisplayGen *)gui view:(MyOpenGLView *)gameView;
 
+   - (NSString *)validateKey:(NSString*)key checkKeys:(NSArray*)check_keys;
+
    - (NSDictionary *)makeKeyGuiDict:(NSString *)what keyDef:(NSString *)keyDef;
    - (NSDictionary *)makeKeyGuiDictHeader:(NSString *)header;
 

--- a/src/Core/OOEquipmentType.h
+++ b/src/Core/OOEquipmentType.h
@@ -69,6 +69,8 @@ SOFTWARE.
 	NSSet					*_incompatibleEquipment;
 	NSArray					*_conditions;
 	NSArray					*_provides;
+	NSArray					*_defaultActivateKey;
+	NSArray					*_defaultModeKey;
 	NSDictionary			*_scriptInfo;
 	NSDictionary			*_weaponInfo;
 	NSString				*_script;
@@ -135,6 +137,9 @@ SOFTWARE.
 
 - (BOOL) fastAffinityDefensive;
 - (BOOL) fastAffinityOffensive;
+
+- (NSArray *) defaultActivateKey;
+- (NSArray *) defaultModeKey;
 
 - (NSUInteger) installTime;
 - (NSUInteger) repairTime;

--- a/src/Core/OOEquipmentType.m
+++ b/src/Core/OOEquipmentType.m
@@ -193,7 +193,6 @@ static NSDictionary		*sMissilesRegistry = nil;
 	NSArray				*conditions = nil;
 	NSString			*condition_script = nil;
 	NSArray				*keydef = nil;
-	int					i;
 
 	self = [super init];
 	if (self == nil)  OK = NO;
@@ -349,9 +348,7 @@ static NSDictionary		*sMissilesRegistry = nil;
 				// look for default activate and mode key settings
 				// note: the customEquipmentActivation array is only populated when starting a game
 				// so the application of any default key settings on equipment will only happen then
-				NSDictionary *item;
 				NSString *checking;
-				BOOL do_update = false;
 
 				object = [extra objectForKey:@"default_activate_key"];
 				if ([object isKindOfClass:[NSArray class]]) keydef = object;
@@ -370,25 +367,7 @@ static NSDictionary		*sMissilesRegistry = nil;
 					if (checking != nil) {
 						OOLog(@"equipment.load", @"***** Error: %@ for equipment item %@ is already in use for %@. Default not applied", @"default_activate_key", _identifier, checking);
 						_defaultActivateKey = nil;
-					} else {
-						// has key for equip already been defined/overridden?
-						// find the custom key definition for this equipment key (_identifier) in the array
-						for (i = 0; i < [[PLAYER customEquipmentActivation] count]; i++) 
-						{
-							item = [[PLAYER customEquipmentActivation] objectAtIndex:i];
-							if ([[item oo_stringForKey:CUSTOMEQUIP_EQUIPKEY] isEqualToString:_identifier]) 
-							{
-								object = [item oo_arrayForKey:CUSTOMEQUIP_KEYACTIVATE];
-								// only update if the item's activate key is empty
-								if (object == nil || [object count] == 0)
-								{
-									do_update = true;
-									[[[PLAYER customEquipmentActivation] objectAtIndex:i] setObject:_defaultActivateKey forKey:CUSTOMEQUIP_KEYACTIVATE];
-								}
-								break;
-							}
-						}
-					}
+					} 
 				}
 
 				object = [extra objectForKey:@"default_mode_key"];
@@ -408,34 +387,8 @@ static NSDictionary		*sMissilesRegistry = nil;
 					if (checking != nil) {
 						OOLog(@"equipment.load", @"***** Error: %@ for equipment item %@ is already in use for %@. Default not applied.", @"default_mode_key", _identifier, checking);
 						_defaultModeKey = nil;
-					} else {
-						// has key for equip already been defined/overridden?
-						// find the custom key definition for this equipment key (_identifier) in the array
-						for (i = 0; i < [[PLAYER customEquipmentActivation] count]; i++) 
-						{
-							item = [[PLAYER customEquipmentActivation] objectAtIndex:i];
-							if ([[item oo_stringForKey:CUSTOMEQUIP_EQUIPKEY] isEqualToString:_identifier]) 
-							{
-								object = [item oo_arrayForKey:CUSTOMEQUIP_KEYMODE];
-								// only update if the item's mode key is empty
-								if (object == nil || [object count] == 0)
-								{
-									do_update = true;
-									[[[PLAYER customEquipmentActivation] objectAtIndex:i] setObject:_defaultModeKey forKey:CUSTOMEQUIP_KEYMODE];
-									break;
-								}
-							}
-						}
-					}
+					} 
 				}
-
-				// do we need to update the defaults?
-				if (do_update) 
-				{
-					NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-					[defaults setObject:[PLAYER customEquipmentActivation] forKey:KEYCONFIG_CUSTOMEQUIP];
-				}
-
 			}
 		}
 	}

--- a/src/Core/Scripting/OOJSEquipmentInfo.m
+++ b/src/Core/Scripting/OOJSEquipmentInfo.m
@@ -55,6 +55,8 @@ enum
 	kEquipmentInfo_equipmentKey,
 	kEquipmentInfo_fastAffinityDefensive,
 	kEquipmentInfo_fastAffinityOffensive,
+	kEquipmentInfo_defaultActivateKey,
+	kEquipmentInfo_defaultModeKey,
 	kEquipmentInfo_incompatibleEquipment,
 	kEquipmentInfo_isAvailableToAll,
 	kEquipmentInfo_isAvailableToNPCs,
@@ -95,6 +97,8 @@ static JSPropertySpec sEquipmentInfoProperties[] =
 	{ "equipmentKey",					kEquipmentInfo_equipmentKey,				OOJS_PROP_READONLY_CB },
 	{ "fastAffinityDefensive",			kEquipmentInfo_fastAffinityDefensive,		OOJS_PROP_READONLY_CB },
 	{ "fastAffinityOffensive",			kEquipmentInfo_fastAffinityOffensive,		OOJS_PROP_READONLY_CB },
+	{ "defaultActivateKey",				kEquipmentInfo_defaultActivateKey,			OOJS_PROP_READONLY_CB },
+	{ "defaultModeKey",					kEquipmentInfo_defaultModeKey,				OOJS_PROP_READONLY_CB },
 	{ "incompatibleEquipment",			kEquipmentInfo_incompatibleEquipment,		OOJS_PROP_READONLY_CB },
 	{ "isAvailableToAll",				kEquipmentInfo_isAvailableToAll,			OOJS_PROP_READONLY_CB },
 	{ "isAvailableToNPCs",				kEquipmentInfo_isAvailableToNPCs,			OOJS_PROP_READONLY_CB },
@@ -298,6 +302,14 @@ static JSBool EquipmentInfoGetProperty(JSContext *context, JSObject *this, jsid 
 		case kEquipmentInfo_fastAffinityOffensive:
 			*value = OOJSValueFromBOOL([eqType fastAffinityOffensive]);
 			return YES;
+
+		case kEquipmentInfo_defaultActivateKey:
+			result = [eqType defaultActivateKey];
+			break;		
+
+		case kEquipmentInfo_defaultModeKey:
+			result = [eqType defaultModeKey];
+			break;		
 
 		case kEquipmentInfo_techLevel:
 			*value = INT_TO_JSVAL((int32_t)[eqType techLevel]);


### PR DESCRIPTION
With this PR, you can now set "default_activate_key" and "default_mode_key" in your equipment.plist definition. If the chosen key conflicts with another key when loading, the setting will be ignored.
The definition is the same as for other key settings, in that it is an array of dictionary items. For example:
```
	default_activate_key = ({key = "0"; shift = true;});
	default_mode_key = ({key = "9"; mod1 = true;});

```
If you change the default key for the equipment item, the "Overrides" column will now show that the key setting has changed from the default.
