### PR TITLE
Fixes issue with too many choices to fit on mission screen

### DIFF
--- a/Doc/CHANGELOG.TXT
+++ b/Doc/CHANGELOG.TXT
@@ -92,6 +92,8 @@ Scripting:
 
 Bug Fixes:
 ==========
+* Prevented native code exception when too many choices have been defined for a 
+  mission screen that will fit on the current screen size.
 * Splinters that have a defined cargo will now spawn with that, instead of 
   defaulting to minerals.
 * Fixed issue where destination ID was not being passed to shipWillEnterWitchspace

--- a/src/Core/Entities/PlayerEntityLegacyScriptEngine.m
+++ b/src/Core/Entities/PlayerEntityLegacyScriptEngine.m
@@ -1991,16 +1991,22 @@ static int shipsFound;
 		// only try this if they're all strings
 		choiceKeys = [choiceKeys sortedArrayUsingSelector:@selector(caseInsensitiveCompare:)];
 	}
-	
+
+	NSInteger keysCount = [choiceKeys count];
+	if ((end_row + 1) < [choiceKeys count]) {
+		OOLogERR(kOOLogException, @"in mission.runScreen choices: number of choices defined (%i) is greater than available lines (%i). Check HUD settings for allowBigGui.",  [choiceKeys count], (end_row + 1));
+		keysCount = end_row + 1;
+	}
+
 	[gui setText:@"" forRow:end_row];				// clears out the 'Press spacebar' message
 	[gui setKey:@"" forRow:end_row];					// clears the key to enable pollDemoControls to check for a selection
 	[gui setSelectableRange:NSMakeRange(0,0)];	// clears the selectable range
 	[UNIVERSE enterGUIViewModeWithMouseInteraction:YES]; // enables mouse selection of the choices list items
 	
-	OOGUIRow			choicesRow = (end_row+1) - [choiceKeys count];
+	OOGUIRow			choicesRow = (end_row+1) - keysCount;
 	NSEnumerator		*choiceEnum = nil;
 	NSString			*choiceKey = nil;
-	id            choiceValue = nil;
+	id            		choiceValue = nil;
 	NSString			*choiceText = nil;
 	
 	BOOL selectableRowExists = NO;
@@ -2073,6 +2079,7 @@ static int shipsFound;
 			[gui setKey:GUI_KEY_SKIP forRow:choicesRow];
 		}
 		choicesRow++;
+		if (choicesRow > (end_row + 1)) break;
 	}
 	
 	if (!selectableRowExists)
@@ -2083,7 +2090,7 @@ static int shipsFound;
 		[gui setColor:[OOColor yellowColor] forRow:end_row];
 	}
 
-	[gui setSelectableRange:NSMakeRange((end_row+1) - [choiceKeys count], [choiceKeys count])];
+	[gui setSelectableRange:NSMakeRange((end_row+1) - keysCount, keysCount)];
 	[gui setSelectedRow: firstSelectableRow];
 	
 	[self resetMissionChoice];


### PR DESCRIPTION
This PR fixes the issue where too many choices have been defined in the options dictionary to fit on the current mission screen.

Essentially, what I'm doing here is (apart from putting a notice in the log) ignoring choices that fall outside the scope of the screen. This could potentially leave the screen in a weird state, if (say) the option to close the screen is one of the excluded options.

As an alternative, I could ignore *all* options if too many have been defined. Let me know your preference.