### PR TITLE
Fixes issue where setting keys for custom equipment was failing

### DIFF
--- a/src/Core/Entities/PlayerEntityKeyMapper.m
+++ b/src/Core/Entities/PlayerEntityKeyMapper.m
@@ -1642,7 +1642,9 @@ static NSArray *camera_keys = nil;
 	{
 		NSUInteger idx = [self getCustomEquipIndex:key];
 		NSString *custkey = [self getCustomEquipKeyDefType:key];
-		[[customEquipActivation objectAtIndex:idx] setObject:key_list forKey:custkey];
+		NSMutableDictionary *custEquip = [[customEquipActivation objectAtIndex:idx] mutableCopy];
+		[custEquip setObject:key_list forKey:custkey];
+		[customEquipActivation replaceObjectAtIndex:idx withObject:custEquip];
 		[defaults setObject:customEquipActivation forKey:KEYCONFIG_CUSTOMEQUIP];
 	}
 	// reload settings


### PR DESCRIPTION
The fail was causing an error to be written to the log, but the app continued to run. See issue #479 
The issue was only occurring in the Linux build, but I have tested this on both Windows and Linux.