### PR TITLE
Introducing -help / --help Command Line Option

### DIFF
--- a/src/SDL/main.m
+++ b/src/SDL/main.m
@@ -70,7 +70,9 @@ int main(int argc, char *argv[])
 	
 #if OOLITE_WINDOWS
 
-	// Detect current working directory and set up GNUstep environment variables
+	#define OO_SHOW_MSG(ooMsg, ooMsgTitle, ooMsgFlags)	MessageBox(NULL, ooMsg, ooMsgTitle, ooMsgFlags)
+ 	
+ 	// Detect current working directory and set up GNUstep environment variables
 	#define MAX_PATH_LEN 256
 	char currentWorkingDir[MAX_PATH_LEN];
 	char envVarString[2 * MAX_PATH_LEN];
@@ -108,6 +110,9 @@ int main(int argc, char *argv[])
 		numbers don't behave strangely.
 	*/
 	setlocale(LC_ALL, "C");
+
+#else // Linux
+	#define OO_SHOW_MSG(ooMsg, ooTitle, ooFlags)	fprintf(stdout, ooMsg)
 #endif
 
 	// Need this because we're not using the default run loop's autorelease
@@ -128,6 +133,30 @@ int main(int argc, char *argv[])
 				i++;
 				if (i < argc)
 					[controller setPlayerFileToLoad: [NSString stringWithCString: argv[i]]];
+			}
+
+   			if (!strcmp("-help", argv[i]) || !strcmp("--help", argv[i]))
+			{
+				char const *processName = [[[NSProcessInfo processInfo] processName] UTF8String];
+				char s[1024];
+				sprintf(s,	"Usage: %s [options]\n\n"
+							"Options can be any of the following: \n\n"
+							"--compile-sysdesc\t\t\tCompile system descriptions\n"
+							"--export-sysdesc\t\t\tExport system descriptions\n"
+							"-hdr\t\t\t\tStart up in HDR mode\n"
+							"-load [filepath]:\t\t\tLoad commander from [filepath]\n"
+							"-message [messageString]\t\tDisplay [messageString] at startup\n"
+							"-noshaders\t\t\tStart up with shaders disabled\n"
+							"-nosplash\t\t\t\tForce disable splash screen on startup\n"
+							"-nosound\t\t\t\tStart up with sound disabled\n"
+							"-novsync\t\t\t\tForce disable V-Sync\n"
+							"--openstep\t\t\tWhen compiling or exporting system\n\t\t\t\tdescriptions, use openstep format\n"
+							"-showversion\t\t\tDisplay version at startup screen\n"
+							"-splash\t\t\t\tForce splash screen on startup\n"
+							"-verify-oxp [filepath]\t\t\tVerify OXP at [filepath]\n"
+							"--xml\t\t\t\tWhen compiling or exporting system \n\t\t\t\tdescriptions, use xml format\n", processName);
+				OO_SHOW_MSG(s, processName, MB_OK);
+				return 2;
 			}
 		}
 		

--- a/src/SDL/main.m
+++ b/src/SDL/main.m
@@ -138,11 +138,11 @@ int main(int argc, char *argv[])
    			if (!strcmp("-help", argv[i]) || !strcmp("--help", argv[i]))
 			{
 				char const *processName = [[[NSProcessInfo processInfo] processName] UTF8String];
-				char s[1024];
+				char s[2048];
 				sprintf(s,	"Usage: %s [options]\n\n"
 							"Options can be any of the following: \n\n"
-							"--compile-sysdesc\t\t\tCompile system descriptions\n"
-							"--export-sysdesc\t\t\tExport system descriptions\n"
+							"--compile-sysdesc\t\t\tCompile system descriptions *\n"
+							"--export-sysdesc\t\t\tExport system descriptions *\n"
 							"-hdr\t\t\t\tStart up in HDR mode\n"
 							"-load [filepath]:\t\t\tLoad commander from [filepath]\n"
 							"-message [messageString]\t\tDisplay [messageString] at startup\n"
@@ -150,11 +150,13 @@ int main(int argc, char *argv[])
 							"-nosplash\t\t\t\tForce disable splash screen on startup\n"
 							"-nosound\t\t\t\tStart up with sound disabled\n"
 							"-novsync\t\t\t\tForce disable V-Sync\n"
-							"--openstep\t\t\tWhen compiling or exporting system\n\t\t\t\tdescriptions, use openstep format\n"
+							"--openstep\t\t\tWhen compiling or exporting system\n\t\t\t\tdescriptions, use openstep format *\n"
 							"-showversion\t\t\tDisplay version at startup screen\n"
 							"-splash\t\t\t\tForce splash screen on startup\n"
-							"-verify-oxp [filepath]\t\t\tVerify OXP at [filepath]\n"
-							"--xml\t\t\t\tWhen compiling or exporting system \n\t\t\t\tdescriptions, use xml format\n", processName);
+							"-verify-oxp [filepath]\t\t\tVerify OXP at [filepath] *\n"
+							"--xml\t\t\t\tWhen compiling or exporting system \n\t\t\t\tdescriptions, use xml format *\n"
+							"\n"
+							"Options marked with \"*\" are available only in Test Release configuration.", processName);
 				OO_SHOW_MSG(s, processName, MB_OK);
 				return 2;
 			}

--- a/src/SDL/main.m
+++ b/src/SDL/main.m
@@ -158,6 +158,7 @@ int main(int argc, char *argv[])
 							"\n"
 							"Options marked with \"*\" are available only in Test Release configuration.", processName);
 				OO_SHOW_MSG(s, processName, MB_OK);
+    				OOLog(@"process.args", @"%s option detected, exiting with code 2 after help page has been displayed.", argv[i]);
 				return 2;
 			}
 		}


### PR DESCRIPTION
This PR aims to assist new players trying to work their way through the game at its early stages. It enables the -help (--help also works) command line option. Entering [-]-help as a command line parameter opens up a message box with the list of available command line options on Windows, while on Linux it sends all output to stdout. The game will exit if the [-]-help parameter is detected in the command line args, immediately after the help info has been displayed. The exit code in this case is 2, which means exiting due to [-]-help found.

A short message indicating the exit reason is sent to the actual log as well. This is to avoid sudden termination of the log file, which could lead to the potential (wrong) assumption that a crash occurred.