### PR TITLE
OXZ Manager - Filter by Category

### DIFF
--- a/Doc/CHANGELOG.TXT
+++ b/Doc/CHANGELOG.TXT
@@ -48,6 +48,7 @@ General:
 * Application startup command is now written to the log file.
 * Implemented [-]-help command line option - shows list of available command line
   switches.
+* OXZ Manager: Implemented filter by category.
 
 Expansion Pack Development:
 ===========================

--- a/Resources/Config/descriptions.plist
+++ b/Resources/Config/descriptions.plist
@@ -1506,7 +1506,7 @@
 	"oolite-oxzmanager-text-prompt-@" 		= "New Filter = %@";
 	"oolite-oxzmanager-currentfilter-is-@"  = "Current filter = %@";
 	"oolite-oxzmanager-currentfilter-is-@-@"  = "Filter ('%@' sets): %@";
-	"oolite-oxzmanager-filterhelp" 			= "Enter a filter to restrict the expansion pack lists, or leave blank to keep the current filter. The following filters are available:\n\n'*' - show everything\n'i' - packs not already installed\n'u' - installed packs with updates available\n'k:<keyword>' - keyword search\n'a:<author>' - author search\n't:<tag>' - tag search\n'd:<integer>' - packs updated in last <integer> days\n\nThe filter entry will turn orange if the currently entered filter is invalid.";
+	"oolite-oxzmanager-filterhelp" 			= "Enter a filter to restrict the expansion pack lists, or leave blank to keep the current filter. The following filters are available:\n\n'*' - show everything\n'i' - packs not already installed\n'u' - installed packs with updates available\n'k:<keyword>' - keyword search\n'a:<author>' - author search\n'c:<category>' - category search\n't:<tag>' - tag search\n'd:<integer>' - packs updated in last <integer> days\n\nThe filter entry will turn orange if the currently entered filter is invalid.";
 
 	"oolite-oxzmanager-infopage-title-@-version-@"	= "Expansion Pack: %@ %@";
 	"oolite-oxzmanager-infopage-author-@"		= "Author: %@";

--- a/src/Core/OOOXZManager.m
+++ b/src/Core/OOOXZManager.m
@@ -68,6 +68,7 @@ static NSString * const kOOOXZFilterUpdates = @"u";
 static NSString * const kOOOXZFilterInstallable = @"i";
 static NSString * const kOOOXZFilterKeyword = @"k:";
 static NSString * const kOOOXZFilterAuthor = @"a:";
+static NSString * const kOOOXZFilterCategory = @"c:";
 static NSString * const kOOOXZFilterDays = @"d:";
 static NSString * const kOOOXZFilterTag = @"t:";
 
@@ -173,6 +174,7 @@ static OOOXZManager *sSingleton = nil;
 - (BOOL) applyFilterByAuthor:(NSDictionary *)manifest author:(NSString *)author;
 - (BOOL) applyFilterByDays:(NSDictionary *)manifest days:(NSString *)days;
 - (BOOL) applyFilterByTag:(NSDictionary *)manifest tag:(NSString *)tag;
+- (BOOL) applyFilterByCategory:(NSDictionary *)manifest category:(NSString *)category;
 
 @end 
 
@@ -396,6 +398,11 @@ static OOOXZManager *sSingleton = nil;
 		filterSelector = @selector(applyFilterByTag:tag:);
 		parameter = [_currentFilter substringFromIndex:[kOOOXZFilterTag length]];
 	}
+ 	else if ([_currentFilter hasPrefix:kOOOXZFilterCategory])
+	{
+		filterSelector = @selector(applyFilterByCategory:category:);
+		parameter = [_currentFilter substringFromIndex:[kOOOXZFilterCategory length]];
+	}
 
 	NSMutableArray *filteredList = [NSMutableArray arrayWithCapacity:[list count]];
 	NSDictionary *manifest       = nil;
@@ -506,6 +513,14 @@ static OOOXZManager *sSingleton = nil;
 	return NO;
 }
 
+
+- (BOOL) applyFilterByCategory:(NSDictionary *)manifest category:(NSString *)category
+{
+	NSString *mCategory = [manifest oo_stringForKey:kOOManifestCategory];
+	return ([mCategory rangeOfString:category options:NSCaseInsensitiveSearch].location != NSNotFound);
+}
+
+
 /*** End filters ***/
 
 - (BOOL) validateFilter:(NSString *)input
@@ -519,6 +534,7 @@ static OOOXZManager *sSingleton = nil;
 		|| ([filter hasPrefix:kOOOXZFilterAuthor] && [filter length] > [kOOOXZFilterAuthor length])
 		|| ([filter hasPrefix:kOOOXZFilterDays] && [[filter substringFromIndex:[kOOOXZFilterDays length]] intValue] > 0)
 		|| ([filter hasPrefix:kOOOXZFilterTag] && [filter length] > [kOOOXZFilterTag length])
+  		|| ([filter hasPrefix:kOOOXZFilterCategory] && [filter length] > [kOOOXZFilterCategory length])
 		)
 	{
 		return YES;


### PR DESCRIPTION
I don't know how we managed to miss the most obvious filter in the OXZ Manager for so long, but this PR aims to remedy the situation. It implements the 'c:<category>' filter, which, when applied, will list only managed expansions belonging to the specified category. So you can write something like c:ships in the filters screen and it will show you only the expansions in the Ships category. You won't have to press More one thousand times to get to Ships anymore.