### PR TITLE
OXZ Manager: Leading whitespaces from string filters are now stripped.

### DIFF
--- a/Doc/CHANGELOG.TXT
+++ b/Doc/CHANGELOG.TXT
@@ -48,7 +48,10 @@ General:
 * Application startup command is now written to the log file.
 * Implemented [-]-help command line option - shows list of available command line
   switches.
+* Internal framerate cap increased from 200 to 240 fps.
 * OXZ Manager: Implemented filter by category.
+* OXZ Manager: Leading whitespaces in text filters are now ignored for reduced
+  confusion.
 
 Expansion Pack Development:
 ===========================

--- a/src/Core/NSStringOOExtensions.h
+++ b/src/Core/NSStringOOExtensions.h
@@ -59,6 +59,30 @@ MA 02110-1301, USA.
 */
 - (uint32_t) oo_hash;
 
+
+/*	-stringByTrimmingLeadingCharactersInSet:
+	Strips characters belonging to selected character set from start of string. 
+*/
+- (NSString *)stringByTrimmingLeadingCharactersInSet:(NSCharacterSet *)characterSet;
+
+
+/*	-stringByTrimmingLeadingWhitespaceAndNewlineCharacters:
+	Strips leading whtiespaces and newline characters from string.
+*/	
+- (NSString *)stringByTrimmingLeadingWhitespaceAndNewlineCharacters;
+
+
+/*	-stringByTrimmingTrailingCharactersInSet:
+	Strips characters belonging to selected character set from end of string. 
+*/
+- (NSString *)stringByTrimmingTrailingCharactersInSet:(NSCharacterSet *)characterSet;
+ 
+ 
+ /*	-stringByTrimmingTrailingWhitespaceAndNewlineCharacters:
+	Strips trailing whtiespaces and newline characters from string.
+*/	
+- (NSString *)stringByTrimmingTrailingWhitespaceAndNewlineCharacters;
+
 @end
 
 

--- a/src/Core/NSStringOOExtensions.m
+++ b/src/Core/NSStringOOExtensions.m
@@ -149,6 +149,36 @@ MA 02110-1301, USA.
 	return hash;
 }
 
+
+- (NSString *)stringByTrimmingLeadingCharactersInSet:(NSCharacterSet *)characterSet
+{
+	NSRange rangeOfFirstWantedCharacter = [self rangeOfCharacterFromSet:[characterSet invertedSet]];
+	if (rangeOfFirstWantedCharacter.location == NSNotFound)  return @"";
+	
+	return [self substringFromIndex:rangeOfFirstWantedCharacter.location];
+}
+
+
+- (NSString *)stringByTrimmingLeadingWhitespaceAndNewlineCharacters
+{
+	return [self stringByTrimmingLeadingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+}
+
+
+- (NSString *)stringByTrimmingTrailingCharactersInSet:(NSCharacterSet *)characterSet
+{
+	NSRange rangeOfLastWantedCharacter = [self rangeOfCharacterFromSet:[characterSet invertedSet] options:NSBackwardsSearch];
+	if (rangeOfLastWantedCharacter.location == NSNotFound)  return @"";
+	
+	return [self substringToIndex:rangeOfLastWantedCharacter.location+1]; // non-inclusive
+}
+
+
+- (NSString *)stringByTrimmingTrailingWhitespaceAndNewlineCharacters
+{
+	return [self stringByTrimmingTrailingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+}
+
 @end
 
 

--- a/src/Core/OOOXZManager.m
+++ b/src/Core/OOOXZManager.m
@@ -454,6 +454,10 @@ static OOOXZManager *sSingleton = nil;
 {
 	NSString *parameter = nil;
 	NSArray *parameters = [NSArray arrayWithObjects:kOOManifestTitle,kOOManifestDescription,kOOManifestCategory,nil];
+ 	
+  	// trim any eventual leading whitespace from input string
+	keyword = [keyword stringByTrimmingLeadingWhitespaceAndNewlineCharacters];
+ 	
 	foreach (parameter,parameters)
 	{
 		if ([[manifest oo_stringForKey:parameter] rangeOfString:keyword options:NSCaseInsensitiveSearch].location != NSNotFound)
@@ -477,6 +481,9 @@ static OOOXZManager *sSingleton = nil;
 
 - (BOOL) applyFilterByAuthor:(NSDictionary *)manifest author:(NSString *)author
 {
+	// trim any eventual leading whitespace from input string
+	author = [author stringByTrimmingLeadingWhitespaceAndNewlineCharacters];
+ 	
 	NSString *mAuth = [manifest oo_stringForKey:kOOManifestAuthor];
 	return ([mAuth rangeOfString:author options:NSCaseInsensitiveSearch].location != NSNotFound);
 }
@@ -502,6 +509,10 @@ static OOOXZManager *sSingleton = nil;
 {
 	NSString *parameter = nil;
 	NSArray *parameters = [manifest oo_arrayForKey:kOOManifestTags];
+
+  	// trim any eventual leading whitespace from input string
+	tag = [tag stringByTrimmingLeadingWhitespaceAndNewlineCharacters];
+ 	
 	foreach (parameter,parameters)
 	{
 		if ([parameter rangeOfString:tag options:NSCaseInsensitiveSearch].location != NSNotFound)
@@ -516,6 +527,9 @@ static OOOXZManager *sSingleton = nil;
 
 - (BOOL) applyFilterByCategory:(NSDictionary *)manifest category:(NSString *)category
 {
+	// trim any eventual leading whitespace from input string
+	category = [category stringByTrimmingLeadingWhitespaceAndNewlineCharacters];
+ 	
 	NSString *mCategory = [manifest oo_stringForKey:kOOManifestCategory];
 	return ([mCategory rangeOfString:category options:NSCaseInsensitiveSearch].location != NSNotFound);
 }


### PR DESCRIPTION
This should fix issue #376 and reduce potential confusion.

Part of this PR are also four new NSString extensions: -stringByTrimmingLeadingCharactersInSet, -stringByTrimmingLeadingWhitespaceAndNewlineCharacters, -stringByTrimmingTrailingCharactersInSet and -stringByTrimmingTrailingWhitespaceAndNewlineCharacters: The last two are not used in this fix, but they are handy and can be useful in the future if need be.

While at it I also applied the same behavior on the remaining string filters, namely author, tag and category.