### PR TITLE
Update main.m

### DIFF
--- a/src/Cocoa/main.m
+++ b/src/Cocoa/main.m
@@ -2,22 +2,32 @@
 #import "OOLoggingExtended.h"
 #import "OODebugFlags.h"
 
-
 #ifndef NDEBUG
+/**
+ * Global debug flags variable, only defined in Debug builds (NDEBUG not set).
+ * Can be used to enable or disable specific debugging features at runtime.
+ */
 NSUInteger gDebugFlags = 0;
 #endif
 
 /**
  * \ingroup cli
- * Entry point for MacOS. Initializes logging and runs NSApplicationMain.
+ * @brief Main entry point for macOS. Initializes logging and runs the application.
  *
- * @param argc the number of command line arguments
- * @param argv the string array values of the command line arguments
- * @return whatever NSApplicationMain returns
+ * This function performs the following steps:
+ *  1. Calls OOLoggingInit() to configure logging for the application.
+ *  2. Invokes NSApplicationMain(), which loads the main nib (or storyboard),
+ *     initializes NSApplication, and starts the event loop.
+ *
+ * @param argc Number of command-line arguments.
+ * @param argv Array of C-string argument values.
+ * @return The exit code returned by NSApplicationMain.
  */
 int main(int argc, const char *argv[])
 {
-	OOLoggingInit();
-	return NSApplicationMain(argc, argv);
-}
+    // Initialize any custom logging subsystems or global log preferences.
+    OOLoggingInit();
 
+    // Launch the Cocoa application, transferring control to the event loop.
+    return NSApplicationMain(argc, argv);
+}


### PR DESCRIPTION
Below is an enhanced, cleaned-up, and documented version of your Objective-C entry-point file. The improvements focus on:

Consistent Formatting & Style
Optional Doxygen-Style Documentation
Clear Separation of Debug/Release Logic
Minor Safety & Clarity (e.g., mention of what OOLoggingInit() and NSApplicationMain do) Feel free to adapt or remove any extra doc comments that do not match your project’s style and guidelines

Key Improvements
Doxygen-Style Comments

Added doc comments describing each step in main(). Provided context for gDebugFlags usage in debug builds. Code Formatting

Used a consistent brace style and indentation for clarity. Debug/Release Logic

The #ifndef NDEBUG block helps keep gDebugFlags out of release builds, ensuring no overhead or accidental debug outputs in production. Self-Documentation

The in-code comments clearly explain the purpose of OOLoggingInit() and NSApplicationMain(). Adopt or remove any suggestions to best align with your project’s existing code standards and documentation practices.