### PR TITLE
Documentation coverage report

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -1,3 +1,4 @@
+---
 name: build-all
 
 on:
@@ -131,7 +132,7 @@ jobs:
     needs: [common-steps]
     strategy:
       matrix:
-        flavour: [pkg-win-snapshot,pkg-win-deployment,pkg-win]
+        flavour: [pkg-win-snapshot, pkg-win-deployment, pkg-win]
     steps:
       ## This is for debugging only and helps developing the workflow.
       # - name: Environment Variables
@@ -205,7 +206,8 @@ jobs:
       - name: install all the necessary packages
         run: |
           sudo apt update
-          sudo apt -y install graphviz
+          sudo apt -y install graphviz lcov
+          sudo pip3 install coverxygen
 
       - name: Checkout Oolite
         uses: actions/checkout@v4
@@ -277,22 +279,25 @@ jobs:
         run: |
           find . -not -path "./oolite/deps/*" -not -path "./oolite/Mac-specific/*" -not -path "./oolite/.git/*"
 
-      #- name: Run doxygen
-      #  uses: mattnotmitt/doxygen-action@v1.9.5
-      #  with:
-      #    working-directory: oolite
-      
+      # - name: Run doxygen
+      #   uses: mattnotmitt/doxygen-action@v1.9.5
+      #   with:
+      #     working-directory: oolite
+
       - name: Run Doxygen
         run: |
           echo Downloaded: ${{ fromJson(steps.download-doxygen.outputs.downloaded_files)[0] }}
           cd oolite
           ../doxygen/doxygen-*/bin/doxygen
+          python3 -m coverxygen --verbose --xml-dir doxygen/xml --src-dir . --output doxygen/coverxygen.info
+          mkdir -p doxygen/html/coverage
+          genhtml doxygen/coverxygen.info -o doxygen/html/coverage
 
-      ## This is for debugging only and helps developing the workflow.
-      # - name: Environment Variables 1
-      #  run: |
-      #    printenv | sort
-      #    find . -not -path "./oolite/deps/*" -not -path "./oolite/Mac-specific/*" -not -path "./oolite/.git/*"
+      # This is for debugging only and helps developing the workflow.
+      - name: Environment Variables 1
+        run: |
+          printenv | sort
+          find . -not -path "./oolite/deps/*" -not -path "./oolite/Mac-specific/*" -not -path "./oolite/.git/*"
 
       - name: create tar ball
         run: |

--- a/Doc/ApiDocIntro.dox
+++ b/Doc/ApiDocIntro.dox
@@ -8,13 +8,15 @@
  * to related information make getting along much easier.
  *
  * In the top of the page you can find the project and version this documentation
- * was created for. In the menu bar below you see three entries.
+ * was created for. In the menu bar below you see four entries.
  *
- * Currently you are reading the main page. The next section 'Classes' allows you
- * to quickly browse the classes used in the project. Alhpabetically, but also
- * graphically through class inheritance diagrams. The 'Files' section allows
- * you to navigate not by class name but by source code location. Use whichever
- * way feels more comfortable for your use case.
+ * Currently you are reading the main page. The next section 'Topics' leads to 
+ * special pages for different topics.
+ * The section 'Classes' allows you to quickly browse the classes used in the 
+ * project. Alhpabetically, but also graphically through class inheritance
+ * diagrams. The 'Files' section allows you to navigate not by class name but by
+ * source code location. Use whichever way feels more comfortable for your use
+ * case.
  *
  * Once you found the class/file of interest, read that page and also look for
  * sections that can be expanded. Here you find inheritance and collaboration
@@ -49,6 +51,7 @@
  * recognize - and this is a small change only.
  *
  * This entry page can be found under Doc/ApiDocIntro.dox.
+ * The current state can be seen in the <a href="coverage/index.html">Documentation Coverage Report</a>.
  *
  * See more at 
  * <a href="https://www.doxygen.nl/manual/docblocks.html">Documenting the code</a>
@@ -69,4 +72,11 @@
   * The command line is parsed and interpreted at various locations in the code.
   * Here are the known functions that participate on cli arguments.
   * 
+  */
+  
+ /**
+  * \defgroup coverage Code Coverage Report
+  * This documentation is created using Doxygen. On top of that
+  * there is a <a href="coverage/index.html">Documentation Coverage Report</a> 
+  * available that was generated using coverxygen.
   */


### PR DESCRIPTION
This allows not only to browse doxygen documentation for Oolite, but also see reports how much has been documented and where improvements may be useful. Hopefully someone with knowledge on the code would add information that others then may use to better understand the code.

The coverage report is available in the doxygen documentation both from the main page as well as in the topics menu.