### PR TITLE
Use generated PDFs in releases

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Extract PDFs
         run: |
-          unzip -u artifacts/oolite-doc.zip
+          unzip -o artifacts/oolite-doc.zip
 
       # This is for debugging only and helps developing the workflow.
       - name: show filesystem before build
@@ -159,7 +159,7 @@ jobs:
 
       - name: Extract PDFs
         run: |
-          unzip -u artifacts/oolite-doc.zip
+          unzip -o artifacts/oolite-doc.zip
 
       # check http://aegidian.org/bb/viewtopic.php?p=281821#p281821
       # this is for debug only; it creates huge logs and takes a long time to execute, yet you never know when you need it


### PR DESCRIPTION
Fixed a chain of events:
- unzip was configured to only overwrite older or nonexisting files
- we decided to keep the old PDFs
- during checkout git would assign new timestamps

Thus the timestamp of the outdated files was later than the generated files and the files would not get overwritten.
