### PR TITLE
Pause in mission screens

### DIFF
--- a/Doc/CHANGELOG.TXT
+++ b/Doc/CHANGELOG.TXT
@@ -55,6 +55,7 @@ General:
 * Updated the wormhole cloud effect.
 * Mouse flight sensitivity made configurable by editing the preferences file.
 * Implemented new ECM visual effect.
+* Pause and unpause game is now allowed in mission screens while docked.
 
 Expansion Pack Development:
 ===========================

--- a/src/Core/Entities/PlayerEntityControls.m
+++ b/src/Core/Entities/PlayerEntityControls.m
@@ -4858,9 +4858,10 @@ static BOOL autopilot_pause;
 		// Pause game, 'p' key
 		exceptionContext = @"pause key";
 		if (([self checkKeyPress:n_key_pausebutton] || joyButtonState[BUTTON_PAUSE]) && (gui_screen != GUI_SCREEN_LONG_RANGE_CHART &&
-				gui_screen != GUI_SCREEN_MISSION && gui_screen != GUI_SCREEN_REPORT &&
+				gui_screen != GUI_SCREEN_REPORT &&
 				gui_screen != GUI_SCREEN_SAVE && gui_screen != GUI_SCREEN_KEYBOARD_ENTRY) )
 		{
+  			BOOL isMissionScreenWithTextEntry = gui_screen == GUI_SCREEN_MISSION && _missionTextEntry;
 			if (!pause_pressed)
 			{
 				if ([gameController isGamePaused])
@@ -4876,13 +4877,19 @@ static BOOL autopilot_pause;
 				}
 				else
 				{
-					saved_script_time = script_time;
-					[[UNIVERSE messageGUI] clear];
-					
-					[UNIVERSE pauseGame];	// 'paused' handler
+    					if (!isMissionScreenWithTextEntry)
+					{
+						saved_script_time = script_time;
+						[[UNIVERSE messageGUI] clear];
+						
+						[UNIVERSE pauseGame];	// 'paused' handler
+      					}
 				}
 			}
-			pause_pressed = YES;
+   			if (!isMissionScreenWithTextEntry)
+      			{
+				pause_pressed = YES;
+    			}
 		}
 		else
 		{

--- a/src/Core/Entities/PlayerEntityControls.m
+++ b/src/Core/Entities/PlayerEntityControls.m
@@ -4877,19 +4877,19 @@ static BOOL autopilot_pause;
 				}
 				else
 				{
-    					if (!isMissionScreenWithTextEntry)
+    				if (!isMissionScreenWithTextEntry)
 					{
 						saved_script_time = script_time;
 						[[UNIVERSE messageGUI] clear];
 						
 						[UNIVERSE pauseGame];	// 'paused' handler
-      					}
+      				}
 				}
 			}
    			if (!isMissionScreenWithTextEntry)
-      			{
+      		{
 				pause_pressed = YES;
-    			}
+    		}
 		}
 		else
 		{


### PR DESCRIPTION
For a very long time, pausing in mission screens was not feasible. I do not have a recollection of why that was the case, but I imagine that at some point during the early Oolite days, mission screens probably had to adhere to design specs and patterns that may not be applicable at this time.

This PR changes things so that now pause and unpause in mission screens is allowed while docked. In the current game version we have plenty of mission screens. We don't have only the Constrictor, Nova etc. screens, but also the cargo, parcel and passenger contract ones, including both the contract lists and the map screens of each contract. Up to now attempting to pause while viewing the passenger contracts, for example, was not an option but for the end user this created a feeling of inconsistency, with some screens allowing pause and others not. The PR normalizes things somewhat.

Text entry mission screens are supported. Pausing during text entry is not possible and if, for some reason, we manage to enter a mission screen with text input while paused (as one can do using the debug console) it is possible to simply unpause and then continue with text entry.

In-flight is not covered by this PR. Maybe at a later stage, but I think in-flight mission screens are rare anyway.

Please advise if you believe that merging this PR could result in breakage and try to see if you can break it by testing various mission screens. Will leave it up for a few days to give time to test.