### PR TITLE
Added workaround for weird compiler behaviour 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![build-all](https://github.com/OoliteProject/oolite/actions/workflows/build-all.yml/badge.svg)](https://github.com/OoliteProject/oolite/actions/workflows/build-all.yml)
 
 [![GitHub release](https://img.shields.io/github/release/OoliteProject/Oolite.svg)](https://github.com/OoliteProject/Oolite/releases/latest)
-     
+
 
 | Windows             | Linux               | OSX            |
 |---------------------|---------------------|----------------|
@@ -19,7 +19,7 @@ Oolite can be heavily customized via expansions. These modify the gameplay, add 
 
 Oolite for all platforms can be built from this repository. Here is a quick
 guide to the source tree.
- 
+
 For end-user documentation, see [oolite.space](http://www.oolite.space/) and
 [Elite Wiki](http://wiki.alioth.net/index.php/Oolite_Main_Page).
 
@@ -87,19 +87,12 @@ dnf install espeak-devel openal-soft-devel libpng-devel SDL_image-devel gcc-objc
 ```bash
 apt -y install git gobjc gnustep-devel make libsdl1.2-dev libvorbis-dev libopenal-dev g++ libespeak-dev libnspr4-dev
 ```
-- Other distros will likely have similar packages available in their repositories. If you find out which packages to install on another Linux distribution, it would be really nice if you could add them here.
-
-- openSUSE Tumbleweed
-
+- openSUSE Tumbleweed:
 Dependencies
 ```bash
-sudo zypper install espeak-devel openal-soft-devel libpng-devel SDL_image-devel gcc-objc mozilla-nspr-devel sdl12_compat_devel SDL2-devel gnustep-base-devel gnustep-make
+zypper install espeak-devel openal-soft-devel libpng-devel SDL_image-devel gcc-objc mozilla-nspr-devel sdl12_compat_devel SDL2-devel gnustep-base-devel gnustep-make
 ```
-Build
-```bash
-source /usr/share/GNUstep/Makefiles/GNUstep.sh
-make -f Makefile release -j${nproc}
-```
+- Other distros will likely have similar packages available in their repositories. If you find out which packages to install on another Linux distribution, it would be really nice if you could add them here.
 
 #### First fetch all the git submodules
 ```bash
@@ -151,6 +144,12 @@ export RPM_PACKAGE_NAME=bla
 
 - If you get errors like `fatal error: jsapi.h: No such file or directory`, you probably forgot to [first fetch all the git submodules](#first-fetch-all-the-git-submodules)
 
+- If you get something like this: `/usr/include/Foundation/Foundation.h:31:9: fatal error: 'objc/objc.h' file not found`, you can try fixing this by running this before compiling:
+```bash
+export CC=gcc
+make clean
+```
+
 - If you get compiler errors, you can try compiling with:
 ```bash
 make -f Makefile release OBJCFLAGS="-fobjc-exceptions -Wno-format-security" -j$(nproc)
@@ -158,7 +157,7 @@ make -f Makefile release OBJCFLAGS="-fobjc-exceptions -Wno-format-security" -j$(
 
 ## Running
 On OS X, you can run from Xcode by clicking on the appropriate icon
-(or choosing 'Run' from the 'Product' menu).  
+(or choosing 'Run' from the 'Product' menu).
 On Linux/BSD/Unix, in a terminal, type `openapp oolite`, or if you compiled it yourself you can run it with `./oolite.app/oolite`.
 
 ## Git

--- a/src/Core/HeadUpDisplay.m
+++ b/src/Core/HeadUpDisplay.m
@@ -838,7 +838,7 @@ OOINLINE void GLColorWithOverallAlpha(const GLfloat *color, GLfloat alpha)
 	
 	OOVerifyOpenGLState();
 	
-	if (_crosshairWidth * lineWidth > 0)
+	if ((_crosshairWidth * lineWidth) > 0)
 	{
 		OOGL(GLScaledLineWidth(_crosshairWidth * lineWidth));
 		[self drawCrosshairs];

--- a/src/Core/OOPriorityQueue.m
+++ b/src/Core/OOPriorityQueue.m
@@ -535,7 +535,7 @@ OOINLINE NSComparisonResult PQCompare(id a, id b, SEL comparator)
 	}
 	
 	[object autorelease];
-	if (_count * 2 <= _capacity)  [self shrinkBuffer];
+	if ((_count * 2) <= _capacity)  [self shrinkBuffer];
 }
 
 


### PR DESCRIPTION
I believe the issue is with gcc 15, possibly a compiler bug, but I didn't investigate further after finding the workaround of adding parentheses. The error looked like this + same thing with the `if (_count * 2 <= _capacity)` line:
```cpp
src/Core/HeadUpDisplay.m: In function ‘-[HeadUpDisplay renderHUD]’:
src/Core/HeadUpDisplay.m:841:13: error: unknown type name ‘_crosshairWidth’
  841 |         if (_crosshairWidth * lineWidth > 0)
      |             ^~~~~~~~~~~~~~~
src/Core/HeadUpDisplay.m:841:41: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘>’ token
  841 |         if (_crosshairWidth * lineWidth > 0)
      |                                         ^
src/Core/HeadUpDisplay.m:841:13: error: declaration in the controlling expression must have an initializer
  841 |         if (_crosshairWidth * lineWidth > 0)
      |             ^~~~~~~~~~~~~~~
src/Core/HeadUpDisplay.m:845:10: error: expected ‘)’ before ‘if’
  845 |         }
      |          ^
      |          )
  846 |
  847 |         if (lineWidth > 0)
      |         ~~
src/Core/HeadUpDisplay.m:841:12: note: to match this ‘(’
  841 |         if (_crosshairWidth * lineWidth > 0)
      |            ^
src/Core/HeadUpDisplay.m:860:1: error: expected expression before ‘}’ token
  860 | }
      | ^
``` 



Also added more compiling troubleshooting info + tiny README cleanup.
Also, as a heads-up: The pre-compiled nightly Linux binaries don't work on Fedora 42 anymore, since the binaries need libgnustep-base.so.1.28 but Fedora 42 has version 1.30.