### PR TITLE
Adding new world event guiSelectedRowChanged

### DIFF
--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -8876,7 +8876,9 @@ static NSString *SliderString(NSInteger amountIn20ths)
 
 	[[UNIVERSE gameView] clearMouse];
 	[[UNIVERSE gameController] setMouseInteractionModeForUIWithMouseInteraction:YES];
-	
+
+	gui_screen = GUI_SCREEN_GAMEOPTIONS;
+
 	// GUI stuff
 	{
 		#define OO_SETACCESSCONDITIONFORROW(condition, row)				\
@@ -9139,7 +9141,6 @@ static NSString *SliderString(NSInteger amountIn20ths)
 	/* ends */
 
 	[self setShowDemoShips:NO];
-	gui_screen = GUI_SCREEN_GAMEOPTIONS;
 
 	[self setShowDemoShips:NO];
 	[UNIVERSE enterGUIViewModeWithMouseInteraction:YES];
@@ -9154,6 +9155,8 @@ static NSString *SliderString(NSInteger amountIn20ths)
 	OOGUIScreenID	oldScreen = gui_screen;
 	
 	[[UNIVERSE gameController] setMouseInteractionModeForUIWithMouseInteraction:YES];
+
+	gui_screen = GUI_SCREEN_OPTIONS;
 
 	if ([self status] == STATUS_DOCKED)
 	{
@@ -9232,7 +9235,6 @@ static NSString *SliderString(NSInteger amountIn20ths)
 	[[UNIVERSE gameView] clearMouse];
 	
 	[self setShowDemoShips:NO];
-	gui_screen = GUI_SCREEN_OPTIONS;
 	
 	[UNIVERSE enterGUIViewModeWithMouseInteraction:YES];
 	
@@ -9438,6 +9440,8 @@ static NSString *last_outfitting_key=nil;
 		BOOL			displayRow = YES;
 		BOOL			weaponMounted = NO;
 		BOOL			guiChanged = (gui_screen != GUI_SCREEN_EQUIP_SHIP);
+
+		gui_screen = GUI_SCREEN_EQUIP_SHIP;
 
 		[gui clearAndKeepBackground:!guiChanged];
 		[gui setTitle:DESC(@"equip-title")];
@@ -9685,7 +9689,6 @@ static NSString *last_outfitting_key=nil;
 
 	chosen_weapon_facing = WEAPON_FACING_NONE;
 	[self setShowDemoShips:NO];
-	gui_screen = GUI_SCREEN_EQUIP_SHIP;
 
 	[self setShowDemoShips:NO];
 	[UNIVERSE enterGUIViewModeWithMouseInteraction:YES];
@@ -9752,7 +9755,9 @@ static NSString *last_outfitting_key=nil;
 	NSDictionary *interfaces = [[self dockedStation] localInterfaces];
 	NSArray		*interfaceKeys = [interfaces keysSortedByValueUsingSelector:@selector(interfaceCompare:)]; // sorts by category, then title
 	int i;
-	
+
+	OOGUIScreenID	oldScreen = gui_screen;
+
 	// GUI stuff
 	{
 		GuiDisplayGen	*gui = [UNIVERSE gui];
@@ -9763,6 +9768,8 @@ static NSString *last_outfitting_key=nil;
 		[gui clearAndKeepBackground:!guiChanged];
 		[gui setTitle:DESC(@"interfaces-title")];
 		
+		gui_screen = GUI_SCREEN_INTERFACES;
+
 		
 		OOGUITabSettings tab_stops;
 		tab_stops[0] = 0;
@@ -9856,8 +9863,6 @@ static NSString *last_outfitting_key=nil;
 
 	[self setShowDemoShips:NO];
 	
-	OOGUIScreenID	oldScreen = gui_screen;
-	gui_screen = GUI_SCREEN_INTERFACES;
 	[self noteGUIDidChangeFrom:oldScreen to:gui_screen];
 	
 	[self setShowDemoShips:NO];

--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -9141,8 +9141,6 @@ static NSString *SliderString(NSInteger amountIn20ths)
 	/* ends */
 
 	[self setShowDemoShips:NO];
-
-	[self setShowDemoShips:NO];
 	[UNIVERSE enterGUIViewModeWithMouseInteraction:YES];
 }
 
@@ -9688,7 +9686,6 @@ static NSString *last_outfitting_key=nil;
 	/* ends */
 
 	chosen_weapon_facing = WEAPON_FACING_NONE;
-	[self setShowDemoShips:NO];
 
 	[self setShowDemoShips:NO];
 	[UNIVERSE enterGUIViewModeWithMouseInteraction:YES];
@@ -9769,7 +9766,6 @@ static NSString *last_outfitting_key=nil;
 		[gui setTitle:DESC(@"interfaces-title")];
 		
 		gui_screen = GUI_SCREEN_INTERFACES;
-
 		
 		OOGUITabSettings tab_stops;
 		tab_stops[0] = 0;
@@ -9859,7 +9855,6 @@ static NSString *last_outfitting_key=nil;
 		}
 	}
 	/* ends */
-
 
 	[self setShowDemoShips:NO];
 	

--- a/src/Core/Entities/PlayerEntityControls.m
+++ b/src/Core/Entities/PlayerEntityControls.m
@@ -136,6 +136,7 @@ static BOOL				switching_chart_screens;
 static BOOL				switching_status_screens;
 //static BOOL				switching_market_screens;
 static BOOL				switching_equipship_screens;
+static BOOL				switching_interface_screens;
 static BOOL				zoom_pressed;
 static BOOL				customView_pressed;
 static BOOL				weaponsOnlineToggle_pressed;
@@ -754,7 +755,7 @@ static NSTimeInterval	time_last_frame;
 			{
 				if ([gui setLastSelectableRow])  result = YES;
 			}
-			
+
 			if (result && [gui selectableRange].length > 1)  [self playMenuNavigationUp];
 			else  [self playMenuNavigationNot];
 
@@ -4673,12 +4674,14 @@ static NSTimeInterval	time_last_frame;
 		if (gui_screen != GUI_SCREEN_MARKET)
 		{
 			[gameView clearKeys];
+			[gui setNoSelectedRow];
 			[self noteGUIWillChangeTo:GUI_SCREEN_MARKET];
 			[self setGuiToMarketScreen];
 		}
 		else
 		{
 			[gameView clearKeys];
+			[gui setNoSelectedRow];
 			[self noteGUIWillChangeTo:GUI_SCREEN_MARKETINFO];
 			[self setGuiToMarketInfoScreen];
 		}
@@ -4704,6 +4707,7 @@ static NSTimeInterval	time_last_frame;
 				{
 					[gameView clearKeys];
 					[self noteGUIWillChangeTo:GUI_SCREEN_SHIPYARD];
+					[gui setNoSelectedRow];
 					[self setGuiToShipyardScreen:0];
 					[gui setSelectedRow:GUI_ROW_SHIPYARD_START];
 					[self showShipyardInfoForSelection];
@@ -4712,6 +4716,7 @@ static NSTimeInterval	time_last_frame;
 				{
 					[gameView clearKeys];
 					[self noteGUIWillChangeTo:GUI_SCREEN_EQUIP_SHIP];
+					[gui setNoSelectedRow];
 					[self setGuiToEquipShipScreen:0];
 					[gui setSelectedRow:GUI_ROW_EQUIPMENT_START];
 				}
@@ -4727,8 +4732,16 @@ static NSTimeInterval	time_last_frame;
 		
 		if ([self checkKeyPress:n_key_gui_screen_interfaces fKey_only:!fKeyAlias])
 		{
-			[self setGuiToInterfacesScreen:0];
-			[gui setSelectedRow:GUI_ROW_INTERFACES_START];
+			if (!switching_interface_screens) {
+				[gui setNoSelectedRow];
+				[self setGuiToInterfacesScreen:0];
+				[gui setSelectedRow:GUI_ROW_INTERFACES_START];
+			}
+			switching_interface_screens = YES;
+		}
+		else 
+		{
+			switching_interface_screens = NO;
 		}
 
 	}

--- a/src/Core/Entities/PlayerEntityLoadSave.m
+++ b/src/Core/Entities/PlayerEntityLoadSave.m
@@ -259,11 +259,11 @@ static uint16_t PersonalityForCommanderDict(NSDictionary *dict);
 			++row;
 		}
 		
+		gui_screen = GUI_SCREEN_NEWGAME;
+
 		[gui setSelectableRange:NSMakeRange(start_row - 2,3 + row - start_row)];
 		[gui setSelectedRow:start_row];
 		[self showScenarioDetails];
-
-		gui_screen = GUI_SCREEN_NEWGAME;
 	
 		if (guiChanged)
 		{

--- a/src/Core/GuiDisplayGen.h
+++ b/src/Core/GuiDisplayGen.h
@@ -286,6 +286,7 @@ typedef OOGUITabStop OOGUITabSettings[GUI_MAX_COLUMNS];
 - (void) setNoSelectedRow;
 - (NSString *) selectedRowText;
 - (NSString *) selectedRowKey;
+- (void) reportSelectedRow:(int) row;
 
 - (void) setShowTextCursor:(BOOL) yesno;
 - (void) setCurrentRow:(OOGUIRow) value;

--- a/src/Core/GuiDisplayGen.m
+++ b/src/Core/GuiDisplayGen.m
@@ -569,7 +569,7 @@ static BOOL _refreshStarChart = NO;
 
 - (void) reportSelectedRow:(int) row
 {
-	[PLAYER doScriptEvent:OOJSID("guiSelectedRow") withArguments:[NSArray arrayWithObjects:[self keyForRow:row], [NSNumber numberWithInt:row], [self selectedRowText], nil]];
+	[PLAYER doScriptEvent:OOJSID("guiSelectedRowChanged") withArguments:[NSArray arrayWithObjects:[self keyForRow:row], [NSNumber numberWithInt:row], [self selectedRowText], nil]];
 }
 
 

--- a/src/Core/GuiDisplayGen.m
+++ b/src/Core/GuiDisplayGen.m
@@ -497,13 +497,16 @@ static BOOL _refreshStarChart = NO;
 
 - (BOOL) setSelectedRow:(OOGUIRow)row
 {
-	if ((row == selectedRow)&&RowInRange(row, selectableRange))
+	if ((row == selectedRow) && RowInRange(row, selectableRange))
+	{
 		return YES;
+	}
 	if (RowInRange(row, selectableRange))
 	{
 		if (![[rowKey objectAtIndex:row] isEqual:GUI_KEY_SKIP])
 		{
 			selectedRow = row;
+			[self reportSelectedRow:row];
 			return YES;
 		}
 	}
@@ -519,6 +522,7 @@ static BOOL _refreshStarChart = NO;
 		if (![[rowKey objectAtIndex:row] isEqual:GUI_KEY_SKIP])
 		{
 			selectedRow = row;
+			[self reportSelectedRow:row];
 			return YES;
 		}
 		row += direction;
@@ -535,6 +539,7 @@ static BOOL _refreshStarChart = NO;
 		if (![[rowKey objectAtIndex:row] isEqual:GUI_KEY_SKIP])
 		{
 			selectedRow = row;
+			[self reportSelectedRow:row];
 			return YES;
 		}
 		row++;
@@ -552,12 +557,19 @@ static BOOL _refreshStarChart = NO;
 		if (![[rowKey objectAtIndex:row] isEqual:GUI_KEY_SKIP])
 		{
 			selectedRow = row;
+			[self reportSelectedRow:row];
 			return YES;
 		}
 		row--;
 	}
 	selectedRow = -1;
 	return NO;
+}
+
+
+- (void) reportSelectedRow:(int) row
+{
+	[PLAYER doScriptEvent:OOJSID("guiSelectedRow") withArguments:[NSArray arrayWithObjects:[self keyForRow:row], [NSNumber numberWithInt:row], [self selectedRowText], nil]];
 }
 
 


### PR DESCRIPTION
This PR adds a new world event, "guiSelectedRowChanged", which is raised any time the player selects a new item on a gui screen. This could happen by using the up and down arrow keys, or by using the mouse.

The goal of this event is to give scripters the ability to see what the player is doing on a screen and respond to it _before_ the player presses the enter key. For instance, looking towards accessibility development, the text of the selected item could be read out to the player audibly as soon as they select it. 

The format of the event is:

`this.guiSelectedRowChanged = function(key, row, text) {
}`

Where
   key (string) = the underlying key code for the selected row, based on the screen currently shown.
   row (int) = the gui screen row index value for the selected row
   text (string) = the text of the selected row

The event will fire on all screens that have any sort of gui element, including the options screen (F2), the game options screen, and any mission screen. Screens where the event doesn't fire are the various chart screens (F6 and F6F6), the system info screen (F7), the manifest screen (F5F5), but only if there is a single page, and the market info screen (F8F8).