### PR TITLE
Don't assume x86_64 when looking for espeak-ng-data.

### DIFF
--- a/ShellScripts/Linux/install_deps_root.sh
+++ b/ShellScripts/Linux/install_deps_root.sh
@@ -51,10 +51,12 @@ run_script() {
     if ! install_package espeak-ng-dev; then
         return 1
     fi
+    # Some distributions put the data in arch-specific paths
+    HOSTARCH="$(usr/bin/arch 2>/dev/null || echo x86_64)"
     if [ ! -d /usr/share/espeak-ng-data ]; then
         if [ ! -d /usr/local/share/espeak-ng-data ]; then
-            if [ ! -d /usr/lib/x86_64-linux-gnu/espeak-ng-data ]; then
-                echo "❌ espeak-ng-data not in /usr/share, /usr/local/share or /usr/lib/x86_64-linux-gnu!"
+            if [ ! -d /usr/lib/"$HOSTARCH"-linux-gnu/espeak-ng-data ]; then
+                echo "❌ espeak-ng-data not in /usr/share, /usr/local/share or /usr/lib/$HOST_ARCH-linux-gnu!"
                 return 1
             fi
         fi

--- a/ShellScripts/common/post_build.sh
+++ b/ShellScripts/common/post_build.sh
@@ -58,9 +58,10 @@ run_script() {
                 cp -rfu "$MINGW_PREFIX/share/espeak-ng-data" "$PROGDIR/Resources"
             else
                 # Linux modern search paths for espeak-ng-data
+                # Some distributions put the data in arch-specific paths, so check for them
                 SEARCH_PATHS=(
                     "/usr/local/share/espeak-ng-data"
-                    "/usr/lib/x86_64-linux-gnu/espeak-ng-data"
+                    "/usr/lib/$(/usr/bin/arch 2>/dev/null || echo x86_64)-linux-gnu/espeak-ng-data"
                     "/usr/share/espeak-ng-data"
                     "/app/share/espeak-ng-data"
                 )


### PR DESCRIPTION
On Debian-like systems, the data is stored in an architecture-dependent location, so on aarch64 the usual location is /usr/share/aarch64-linux-gnu.

(Almost certainly safe to assume *-linux-gnu, so this patch still does that.)