### PR TITLE
Windows-deps submodule removed

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,3 @@
 [submodule "deps/mozilla"]
 	path = deps/mozilla
 	url = https://github.com/OoliteProject/spidermonkey-ff4.git
-[submodule "deps/Windows-deps"]
-	path = deps/Windows-deps
-	url = https://github.com/OoliteProject/oolite-windows-dependencies.git


### PR DESCRIPTION
Windows-deps submodule removed using approach described here: https://bb.oolite.space/viewtopic.php?p=304803&sid=8f1bdc4e93e44a685eda6376b976cf83#p304803

The submodule is not needed for the modern build.