### PR TITLE
Build all on pull request and regex fix for /usr/local exclusion

### DIFF
--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -2,6 +2,7 @@ name: Build Oolite package for various platforms
 on:
   workflow_dispatch:
   push:
+  pull_request:
 
 jobs:
   build-linux:

--- a/.github/workflows/test_builds.yaml
+++ b/.github/workflows/test_builds.yaml
@@ -1,5 +1,6 @@
 name: Test Oolite package on various platforms
 on:
+  workflow_dispatch:
   push:
   pull_request:
 

--- a/ShellScripts/common/post_build.sh
+++ b/ShellScripts/common/post_build.sh
@@ -101,7 +101,7 @@ run_script() {
         # If we're using GNUstep libraries that aren't in a system folder copy them
         ldd "$PROGDIR/$DEST_BIN" | \
             grep -E "libgnustep-base|libobjc\.so\." | \
-            grep -vE "^/(usr/|usr/local/)?lib(64)?/" | \
+            grep -vE "^[[:space:]]*.*=>[[:space:]]*/(usr/(local/)?|lib(64)?/)" | \
             awk '{print $3}' | \
             xargs -I {} cp -Lrfu {} "$PROGDIR/"
     fi


### PR DESCRIPTION
Adds build on PR not just push so we can ensure that for PRs not only that the test runs on all platforms, but that packages can be successfully built
Fixes /usr/local exclusion issue found by LoneWolf https://bb.oolite.space/viewtopic.php?p=305180#p305180
