### PR TITLE
prevent parallel and duplicate executions to reduce CPU minutes

### DIFF
--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   common:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_builds.yaml
+++ b/.github/workflows/test_builds.yaml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ubuntu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Github fires different events, and some of them so fast that we get duplicate executions of the same workflow on the same commit. With this change only one such invocation would run through while duplicates get cancelled.