### PR TITLE
Allow install_deps.sh to be run standalone as an upgrader (without setup.cmd)

### DIFF
--- a/ShellScripts/Windows/install_deps.sh
+++ b/ShellScripts/Windows/install_deps.sh
@@ -5,63 +5,75 @@
 # One parameter clang = build clang only
 
 install() {
-	# First parameter is package name
-	# Second optional parameter is gcc or clang
+    # First parameter is package name
+    # Second optional parameter is gcc or clang
     echo "Installing $1 package"
 
     local fullname
     if [ -z "$2" ]; then
-		fullname=$1
+        fullname=$1
     else
-		fullname="${1}_${2}"
+        fullname="${1}_${2}"
     fi
 
     local packagename="$MINGW_PACKAGE_PREFIX-$fullname*any.pkg.tar.zst"
-	local filename=$(ls $packagename 2>/dev/null)
+    local filename=$(ls $packagename 2>/dev/null)
 
-	# package file eg. mingw-w64-x86_64-libobjc2-2.3-3-any.pkg.tar.zst
+    # package file eg. mingw-w64-x86_64-libobjc2-2.3-3-any.pkg.tar.zst
     if [ -z "$filename" ]; then
         echo "❌ No file matching $packagename found!" >&2
         return 1
     fi
 
     if ! pacman -U $filename --noconfirm ; then
-	    echo "❌ $filename install failed!" >&2
-	    return 1
-	fi
+        echo "❌ $filename install failed!" >&2
+        return 1
+    fi
 }
 
 run_script() {
     local SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
     pushd "$SCRIPT_DIR"
 
+    local oolite_deps_url="https://api.github.com/repos/OoliteProject/oolite_windeps_build/releases/latest"
+
+    pacman -Syu --noconfirm
     pacman -S git --noconfirm
     pacman -S dos2unix --noconfirm
     pacman -S pactoys --noconfirm
     pacboy -S binutils --noconfirm
-    pacboy -S uutils-coreutils --noconfirm
     pacboy -S python-pip --noconfirm
-    pacboy -S mesa --noconfirm
-    pacboy -S sdl3 --noconfirm
-
-    cd ../../build/packages
-    echo "Installing common libraries"
-    local package_names=(spidermonkey)
-    for packagename in "${package_names[@]}"; do
-        if ! install $packagename; then
-          return 1
-        fi
-    done
-
+    pacman -S make --noconfirm
+    pacboy -S meson --noconfirm
+    pacboy -S ninja --noconfirm
+    pacboy -S nsis --noconfirm
     pacboy -S libpng --noconfirm
     pacboy -S openal --noconfirm
     pacboy -S libvorbis --noconfirm
     pacboy -S pcaudiolib --noconfirm
     pacboy -S espeak-ng --noconfirm
-    pacman -S make --noconfirm
-    pacboy -S meson --noconfirm
-    pacboy -S ninja --noconfirm
-    pacboy -S nsis --noconfirm
+    pacboy -S mesa --noconfirm
+    pacboy -S sdl3 --noconfirm
+
+    cd ../../build
+    mkdir -p packages
+    cd packages
+    curl -s "$oolite_deps_url" | \
+    grep -oP '"browser_download_url": "\K[^"]+' | \
+    while read -r url; do
+        raw_filename="${url##*/}"
+        clean_filename=$(printf '%b' "${raw_filename//%/\\x}")
+        echo "Downloading: $clean_filename"
+        curl -L "$url" -o "$clean_filename"
+    done
+
+    echo "Installing common packages"
+    local package_names=(spidermonkey)
+    for packagename in "${package_names[@]}"; do
+        if ! install $packagename; then
+            return 1
+        fi
+    done
 
     if [[ -z "$1" || "$1" == "clang" ]]; then
         pacboy -S clang --noconfirm
@@ -73,10 +85,10 @@ run_script() {
         local clang_package_names=(libobjc2 gnustep-make gnustep-base)
         for packagename in "${clang_package_names[@]}"; do
             if ! install $packagename clang; then
-              return 1
+                return 1
             fi
         done
-    	pacman -Q > installed-packages-clang.txt
+        pacman -Q > installed-packages-clang.txt
     else
         echo "Installing GNUStep libraries with gcc"
         export cc=$MINGW_PREFIX/bin/gcc
@@ -84,10 +96,10 @@ run_script() {
         local gcc_package_names=(gnustep-make gnustep-base)
         for packagename in "${gcc_package_names[@]}"; do
             if ! install $packagename gcc; then
-              return 1
+                return 1
             fi
         done
-    	pacman -Q > installed-packages-gcc.txt
+        pacman -Q > installed-packages-gcc.txt
     fi
 
     echo "source $MINGW_PREFIX/share/GNUstep/Makefiles/GNUstep.sh" > /etc/profile.d/GNUstep.sh
@@ -108,7 +120,6 @@ EOF
 
 run_script "$@"
 status=$?
-
 
 # Exit only if not sourced
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/ShellScripts/Windows/install_deps.sh
+++ b/ShellScripts/Windows/install_deps.sh
@@ -102,8 +102,6 @@ run_script() {
         pacman -Q > installed-packages-gcc.txt
     fi
 
-    echo "source $MINGW_PREFIX/share/GNUstep/Makefiles/GNUstep.sh" > /etc/profile.d/GNUstep.sh
-
     if ! grep -q "# Custom history settings" ~/.bashrc; then
         cat >> ~/.bashrc <<'EOF'
 # Custom history settings

--- a/ShellScripts/Windows/setup.cmd
+++ b/ShellScripts/Windows/setup.cmd
@@ -14,13 +14,6 @@ set /p INSTALL_PATH=Enter the installation path for MSYS2:
 :: Prompt the user for UCRT64 Clang or MinGW64 GCC
 set /p UCRT_CLANG_OR_MINGW_GCC=Enter 1 for UCRT64 Clang or 2 for MinGW64 GCC: 
 
-:: Where to download Oolite dependencies
-set OOLITE_DEPS_URL=https://api.github.com/repos/OoliteProject/oolite_windeps_build/releases/latest
-mkdir packages
-
-echo === Download Oolite dependencies ===
-powershell -NoLogo -NoProfile -Command "$release=Invoke-RestMethod %OOLITE_DEPS_URL%; foreach ($asset in $release.assets) {Invoke-WebRequest $asset.browser_download_url -OutFile (Join-Path packages $asset.name)}"
-
 :: Where to download installer
 set MSYS2_URL=https://github.com/msys2/msys2-installer/releases/latest/download/msys2-base-x86_64-latest.sfx.exe
 set INSTALLER=%TEMP%\msys2-base.sfx.exe

--- a/installers/flatpak/flatpak_build.sh
+++ b/installers/flatpak/flatpak_build.sh
@@ -11,7 +11,7 @@ source ShellScripts/Linux/install_freedesktop_fn.sh
 
 export ADDITIONAL_CFLAGS="-DBUILD_DATE='\"$CPP_DATE\"'"
 export ADDITIONAL_OBJCFLAGS="-DBUILD_DATE='\"$CPP_DATE\"'"
-make release-deployment -j$FLATPAK_BUILDER_N_JOBS
+make release-deployment
 
 ABS_OOLITEDIR=$(realpath -m "build/meson_deployment/oolite.app")
 install_freedesktop $ABS_OOLITEDIR /app lib/debug/bin metainfo

--- a/installers/flatpak/flatpak_build.sh
+++ b/installers/flatpak/flatpak_build.sh
@@ -6,7 +6,6 @@
 echo "I am flatpak_build.sh $@"
 printenv | sort
 
-source /app/share/GNUstep/Makefiles/GNUstep.sh
 source ShellScripts/common/get_version.sh
 source ShellScripts/Linux/install_freedesktop_fn.sh
 

--- a/src/meson/windows/meson.build
+++ b/src/meson/windows/meson.build
@@ -28,5 +28,9 @@ foreach lib : dep_libs
     oolite_dependencies += [cc.find_library(lib, required: true)]
 endforeach
 if (ccid == 'gcc')
-    add_project_arguments('-DSTATIC_JS_API', language: c_family)
+    add_project_arguments(
+        '-DSTATIC_JS_API',
+        '-D_WIN32_WINNT=0x0A00',
+        language: c_family
+    )
 endif


### PR DESCRIPTION
Remove sourcing of GNUstep.sh
Also fix gcc build on msys2
Reformat install_deps.sh to be 4 spaced

Fixes https://github.com/OoliteProject/oolite/issues/668
Fixes https://github.com/OoliteProject/oolite/issues/670
Fixes https://github.com/OoliteProject/oolite/issues/675