### PR TITLE
readthedocs: remove sourcing of get_version.sh

### DIFF
--- a/Documentation/build_referencesheet_fn.sh
+++ b/Documentation/build_referencesheet_fn.sh
@@ -11,7 +11,6 @@ build_referencesheet() {
     fi
 
     cd ..
-    source ShellScripts/common/get_version.sh
     mkdir -p build/documentation/docs/reference
     cd build/documentation/
     cp ../../Doc/OoliteRS.odt ./reference.odt


### PR DESCRIPTION
Fixes https://github.com/OoliteProject/oolite/issues/685

The readthedocs build started to work after the mk.sh PR was merged. Turns out the get_version.sh file correctly exits with: 
❌ Parent process is sh, Bash parent is build_referencesheet_fn.sh. This file can only be called by meson or sourced by create_flatpak_fn.sh!

That error didn't cause the readthedocs build to fail, it just continued after the line sourcing get_version.sh and completed successfully. However, to prevent confusion better to remove the sourcing altogether as it's not needed.

A lot of explanation for deleting one line :-)