### PR TITLE
Add procps package and fix release error and ordering

### DIFF
--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -226,15 +226,14 @@ jobs:
           name: "Oolite ${{ steps.version.outputs.VER_FULL }}"
           tag_name: "${{ steps.version.outputs.VER_FULL }}"
           prerelease: true
-          preserve_order: true
           files: |
+            artifacts/oolite-windows-nsis-deployment/OoliteInstall-*.exe
+            artifacts/oolite-windows-nsis-test/OoliteInstall-*.exe
+            artifacts/oolite-windows-nsis-dev/OoliteInstall-*.exe
             artifacts/oolite-linux-appimage-deployment/*.AppImage
             artifacts/oolite-linux-appimage-test/*.AppImage
             artifacts/oolite-linux-appimage-dev/*.AppImage
             artifacts/oolite-linux-flatpak-deployment/*.flatpak
-            artifacts/oolite-windows-nsis-deployment/OoliteInstall-*.exe
-            artifacts/oolite-windows-nsis-test/OoliteInstall-*.exe
-            artifacts/oolite-windows-nsis-dev/OoliteInstall-*-dev.exe
 
       - name: Remove old workflow runs
         if: github.ref == 'refs/heads/master' || endsWith(github.ref, 'maintenance')

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -226,6 +226,7 @@ jobs:
           name: "Oolite ${{ steps.version.outputs.VER_FULL }}"
           tag_name: "${{ steps.version.outputs.VER_FULL }}"
           prerelease: true
+          preserve_order: true
           files: |
             artifacts/oolite-windows-nsis-deployment/OoliteInstall-*.exe
             artifacts/oolite-windows-nsis-test/OoliteInstall-*.exe

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -228,13 +228,13 @@ jobs:
           prerelease: true
           preserve_order: true
           files: |
-            artifacts/oolite-windows-nsis-deployment/OoliteInstall-*.exe
-            artifacts/oolite-windows-nsis-test/OoliteInstall-*.exe
-            artifacts/oolite-windows-nsis-dev/OoliteInstall-*-dev.exe
             artifacts/oolite-linux-appimage-deployment/*.AppImage
             artifacts/oolite-linux-appimage-test/*.AppImage
             artifacts/oolite-linux-appimage-dev/*.AppImage
             artifacts/oolite-linux-flatpak-deployment/*.flatpak
+            artifacts/oolite-windows-nsis-deployment/OoliteInstall-*.exe
+            artifacts/oolite-windows-nsis-test/OoliteInstall-*.exe
+            artifacts/oolite-windows-nsis-dev/OoliteInstall-*-dev.exe
 
       - name: Remove old workflow runs
         if: github.ref == 'refs/heads/master' || endsWith(github.ref, 'maintenance')

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -220,13 +220,12 @@ jobs:
       # It should move the 'latest' tag automatically.
       - name: Create Release
         id: create_release
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: softprops/action-gh-release@v3
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          # automatic_release_tag: "latest"
-          automatic_release_tag: "${{ steps.version.outputs.VER_FULL }}"
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          name: "Oolite ${{ steps.version.outputs.VER_FULL }}"
+          tag_name: "${{ steps.version.outputs.VER_FULL }}"
           prerelease: true
-          title: "Oolite ${{ steps.version.outputs.VER_FULL }}"
           files: |
             artifacts/oolite-windows-nsis-deployment/OoliteInstall-*.exe
             artifacts/oolite-windows-nsis-test/OoliteInstall-*.exe
@@ -235,6 +234,7 @@ jobs:
             artifacts/oolite-linux-appimage-test/*.AppImage
             artifacts/oolite-linux-appimage-dev/*.AppImage
             artifacts/oolite-linux-flatpak-deployment/*.flatpak
+
       - name: Remove old workflow runs
         if: github.ref == 'refs/heads/master' || endsWith(github.ref, 'maintenance')
         uses: Mattraks/delete-workflow-runs@v2

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -67,7 +67,7 @@ jobs:
         with:
           name: oolite-linux-appimage-${{matrix.flavour}}
           path: |
-            build/oolite*.AppImage
+            build/Oolite*.AppImage
           retention-days: 5
 
   build-flatpak:

--- a/ShellScripts/Linux/install_package_fn.sh
+++ b/ShellScripts/Linux/install_package_fn.sh
@@ -10,7 +10,12 @@ install_package() {
     # This CASE statement is the dictionary.
     # Add your packages here.
     case "$generic_name" in
-        "git") pkg_name="git" ;;
+        "procps")
+            case "$CURRENT_DISTRO" in
+                debian) pkg_name="procps" ;;
+                redhat) pkg_name="procps-ng" ;;
+                arch) pkg_name="procps-ng" ;;
+            esac ;;
 
         "base-devel")
             case "$CURRENT_DISTRO" in

--- a/ShellScripts/Linux/install_packages_root.sh
+++ b/ShellScripts/Linux/install_packages_root.sh
@@ -17,6 +17,9 @@ run_script() {
     source install_gitversion_fn.sh
     source install_package_fn.sh
 
+    if ! install_package procps; then
+        return 1
+    fi
     if ! install_package base-devel; then
         return 1
     fi

--- a/installers/appimage/create_appimage_fn.sh
+++ b/installers/appimage/create_appimage_fn.sh
@@ -41,7 +41,7 @@ create_appimage() {
     else
         suffix="-$ver_full"
     fi
-    local OUTNAME="oolite${suffix}-${arch}.AppImage"
+    local OUTNAME="Oolite${suffix}-${arch}.AppImage"
     export OUTNAME
 
     echo "Building AppDir for AppImage..."

--- a/installers/appimage/create_appimage_fn.sh
+++ b/installers/appimage/create_appimage_fn.sh
@@ -35,13 +35,7 @@ create_appimage() {
     export ICON
     local DESKTOP="$appshr/applications/space.oolite.Oolite.desktop"
     export DESKTOP
-    local suffix
-    if [[ "$build_type" != "deployment" ]]; then
-        suffix="_$build_type-$ver_full"
-    else
-        suffix="-$ver_full"
-    fi
-    local OUTNAME="Oolite${suffix}-${arch}.AppImage"
+    local OUTNAME="Oolite-$ver_full-$build_type-$arch.AppImage"
     export OUTNAME
 
     echo "Building AppDir for AppImage..."

--- a/installers/appimage/create_appimage_fn.sh
+++ b/installers/appimage/create_appimage_fn.sh
@@ -35,7 +35,7 @@ create_appimage() {
     export ICON
     local DESKTOP="$appshr/applications/space.oolite.Oolite.desktop"
     export DESKTOP
-    local OUTNAME="Oolite_$arch_$ver_full-$build_type.AppImage"
+    local OUTNAME="Oolite-$ver_full-$build_type-$arch.AppImage"
     export OUTNAME
 
     echo "Building AppDir for AppImage..."

--- a/installers/appimage/create_appimage_fn.sh
+++ b/installers/appimage/create_appimage_fn.sh
@@ -35,7 +35,7 @@ create_appimage() {
     export ICON
     local DESKTOP="$appshr/applications/space.oolite.Oolite.desktop"
     export DESKTOP
-    local OUTNAME="Oolite-$ver_full-$build_type-$arch.AppImage"
+    local OUTNAME="Oolite_$arch_$ver_full-$build_type.AppImage"
     export OUTNAME
 
     echo "Building AppDir for AppImage..."

--- a/installers/flatpak/create_flatpak_fn.sh
+++ b/installers/flatpak/create_flatpak_fn.sh
@@ -91,8 +91,8 @@ create_flatpak() {
         return 1
     fi
 
-    local ARCH=$(uname -m)
-    local filename="space.oolite.Oolite-$ver_full-$build_type-$ARCH.flatpak"
+    local arch=$(uname -m)
+    local filename="space.oolite.Oolite_$arch_$ver_full-$build_type.flatpak"
     echo "Creating Flatpak $filename..."
     if ! flatpak build-bundle \
       repo \

--- a/installers/flatpak/create_flatpak_fn.sh
+++ b/installers/flatpak/create_flatpak_fn.sh
@@ -91,14 +91,8 @@ create_flatpak() {
         return 1
     fi
 
-    local suffix
-    if [[ "$build_type" != "deployment" ]]; then
-        suffix="_$build_type-$ver_full"
-    else
-        suffix="-$ver_full"
-    fi
     local ARCH=$(uname -m)
-    local filename="space.oolite.Oolite${suffix}-${ARCH}.flatpak"
+    local filename="space.oolite.Oolite-$ver_full-$build_type-$ARCH.flatpak"
     echo "Creating Flatpak $filename..."
     if ! flatpak build-bundle \
       repo \

--- a/installers/flatpak/create_flatpak_fn.sh
+++ b/installers/flatpak/create_flatpak_fn.sh
@@ -92,7 +92,7 @@ create_flatpak() {
     fi
 
     local arch=$(uname -m)
-    local suffix="-$arch-$ver_full-$build_type"
+    local suffix="-$ver_full-$build_type-$arch"
     local filename="space.oolite.Oolite${suffix}.flatpak"
     echo "Creating Flatpak $filename..."
     if ! flatpak build-bundle \

--- a/installers/flatpak/create_flatpak_fn.sh
+++ b/installers/flatpak/create_flatpak_fn.sh
@@ -92,7 +92,8 @@ create_flatpak() {
     fi
 
     local arch=$(uname -m)
-    local filename="space.oolite.Oolite_$arch_$ver_full-$build_type.flatpak"
+    local suffix="-$arch-$ver_full-$build_type"
+    local filename="space.oolite.Oolite${suffix}.flatpak"
     echo "Creating Flatpak $filename..."
     if ! flatpak build-bundle \
       repo \
@@ -101,7 +102,7 @@ create_flatpak() {
         echo "❌ Flatpak bundle creation failed!" >&2
         return 1
     fi
-    local debugname="space.oolite.Oolite.Debug${suffix}-${ARCH}.flatpak"
+    local debugname="space.oolite.Oolite.Debug${suffix}.flatpak"
     if ! flatpak build-bundle \
       --runtime \
       repo \

--- a/installers/win32/OOlite.nsi
+++ b/installers/win32/OOlite.nsi
@@ -36,7 +36,7 @@
 !define EXTVER "-test"  ; Official distribution with OXP developer tools
 !define ADDCHANGELOG 1	; Official distributions go with a changelog file
 !else
-!define EXTVER ""
+!define EXTVER "-deployment"
 !define ADDCHANGELOG 1	; Official distributions go with a changelog file
 !endif
 !else


### PR DESCRIPTION
Fixes https://github.com/OoliteProject/oolite/issues/696

Build job failed in GH Actions: https://github.com/mcarans/oolite/actions/runs/29538841631/job/87758292443. Changed release action to softprops/action-gh-release@v3 to fix.

Then noticed release assets not ordered correctly (1 appimage, then 3 win exes, then 2 appimages, then flatpaks; also deployment build not the first one for appimage and win) so fixed naming: see https://github.com/mcarans/oolite/releases/tag/1.93.1-procps.6 for new ordering (GitHub orders alphabetically so it's the best I could do given current filename structures and naming conventions.)

I think that in a future PR we should consider making test (the debug console enabled release) into the standard release and drop deployment unless there's an important reason to keep deployment or big disadvantage to always enabling the console such as performance. Happy for someone to tell me why we need deployment. It would simplify things to have 2 builds instead of 3.