### PR TITLE
Common initialiseGLWithSize method 

### DIFF
--- a/src/Core/Entities/PlayerEntity.h
+++ b/src/Core/Entities/PlayerEntity.h
@@ -1302,8 +1302,6 @@ typedef enum
 
 - (void) showShipModelWithKey:(NSString *)shipKey shipData:(NSDictionary *)shipData personality:(uint16_t)personality factorX:(GLfloat)factorX factorY:(GLfloat)factorY factorZ:(GLfloat)factorZ inContext:(NSString *)context;
 
-- (void) doGuiScreenResizeUpdates;
-
 /* Fractional expression of amount of entry inside a planet's atmosphere. 0.0f is out of atmosphere,
    1.0f is fully in and is normally associated with the point of ship destruct due to altitude.
 */

--- a/src/Core/Entities/PlayerEntity.m
+++ b/src/Core/Entities/PlayerEntity.m
@@ -4114,31 +4114,6 @@ NSComparisonResult marketSorterByMassUnit(id a, id b, void *market);
 }
 
 
-// Game options and status screens (for now) may require an immediate window redraw after
-// said window has been resized. This method must be called after such resize events, including
-// toggle to/from full screen - Nikos 20140129
-- (void) doGuiScreenResizeUpdates
-{
-	switch ([self guiScreen])
-	{
-		case GUI_SCREEN_GAMEOPTIONS:
-			//refresh play windowed / full screen
-			[self setGuiToGameOptionsScreen];
-			break;
-		case GUI_SCREEN_STATUS:
-			// status screen must be redone in order to possibly
-			// refresh displayed model's draw position
-			[self setGuiToStatusScreen];
-			break;
-		default:
-			break;
-	}
-
-
-	[hud resetGuiPositions];
-}
-
-
 // Check for lost targeting - both on the ships' main target as well as each
 // missile.
 // If we're actively scanning and we don't have a current target, then check

--- a/src/Core/HeadUpDisplay.h
+++ b/src/Core/HeadUpDisplay.h
@@ -295,7 +295,6 @@ enum
 - (id) initWithDictionary:(NSDictionary *)hudinfo inFile:(NSString *)hudFileName;
 
 - (void) resetGuis:(NSDictionary *)info;
-- (void) resetGuiPositions;
 
 - (NSString *) hudName;
 - (void) setHudName:(NSString *)newHudName;

--- a/src/Core/HeadUpDisplay.m
+++ b/src/Core/HeadUpDisplay.m
@@ -401,27 +401,6 @@ OOINLINE void GLColorWithOverallAlpha(const GLfloat *color, GLfloat alpha)
 }
 
 
-- (void) resetGuiPositions
-{
-	NSDictionary *hudDict = [ResourceManager dictionaryFromFilesNamed:[self hudName] inFolder:@"Config" andMerge:YES];
-
-	GuiDisplayGen*	gui = [UNIVERSE messageGUI];
-	NSDictionary*	gui_info = [hudDict oo_dictionaryForKey:@"message_gui"];
-	if (gui && gui_info)
-	{
-		[self resetGuiPosition:gui withInfo:gui_info];
-	}
-
-	gui = [UNIVERSE commLogGUI];
-	gui_info = [hudDict oo_dictionaryForKey:@"comm_log_gui"];
-	if (gui && gui_info)
-	{
-		[self resetGuiPosition:gui withInfo:gui_info];
-	}
-
-}
-
-
 - (void) resetGuis:(NSDictionary *)info
 {
 	// check for entries in hud.plist for message_gui and comm_log_gui

--- a/src/SDL/MyOpenGLView.h
+++ b/src/SDL/MyOpenGLView.h
@@ -226,8 +226,6 @@ extern int debug;
 
 #if OOLITE_WINDOWS
 
-	BOOL				wasFullScreen;
-	BOOL				updateContext;
 	BOOL				saveSize;
 	BOOL				atDesktopResolution;
 	unsigned			keyboardMap; // *** FLAGGED for deletion

--- a/src/SDL/MyOpenGLView.m
+++ b/src/SDL/MyOpenGLView.m
@@ -447,12 +447,6 @@ enum PreferredAppMode
 
 	OOLog(@"display.mode.list", @"%@", @"CREATING MODE LIST");
 
-
-
-#if OOLITE_WINDOWS
-	ShowWindow(windowHandle,SW_SHOWMINIMIZED);
-	updateContext = !showSplashScreen;
-#endif
 	if (!showSplashScreen)
 	{
 		// blank the surface / go to fullscreen
@@ -497,14 +491,11 @@ enum PreferredAppMode
 		}
 	}
 
-	wasFullScreen = !fullScreen;
-	updateContext = YES;
 #endif
 	SDL_SetWindowResizable(window, true);
 	SDL_SetWindowBordered(window, true);
     if (!showSplashScreen)  return;
 
-#if OOLITE_LINUX
 	if (fullScreen)
 	{
 		SDL_SetWindowFullscreen(window, true);
@@ -533,8 +524,6 @@ enum PreferredAppMode
 		OOLog(@"display.splash", @"Suppressed splash-screen event %d: %d ", numEvents, dummyEvent.type);
 		*/
 	}
-
-#endif // OOLITE_LINUX
 
 	[self updateScreen];
 	[self autoShowMouse];

--- a/src/SDL/MyOpenGLView.m
+++ b/src/SDL/MyOpenGLView.m
@@ -712,21 +712,9 @@ enum PreferredAppMode
 - (void) toggleScreenMode
 {
 	[self setFullScreenMode: !fullScreen];
-#if OOLITE_WINDOWS
-	[self getCurrentMonitorInfo:&monitorInfo];
-#endif
  	if(fullScreen)
 	{
-#if OOLITE_WINDOWS
-		if(![self isRunningOnPrimaryDisplayDevice])
-		{
-			[self initialiseGLWithSize:NSMakeSize(monitorInfo.rcMonitor.right - monitorInfo.rcMonitor.left,
-												monitorInfo.rcMonitor.bottom - monitorInfo.rcMonitor.top)];
-		}
-		else  [self initialiseGLWithSize:[self modeAsSize: currentSize]];
-#else
  		[self initialiseGLWithSize:[self modeAsSize: currentSize]];
-#endif
 	}
 	else
 	{

--- a/src/SDL/MyOpenGLView.m
+++ b/src/SDL/MyOpenGLView.m
@@ -1450,10 +1450,12 @@ finished:
 	viewSize = v_size;
 	OOLog(@"display.initGL", @"Requested a new surface of %d x %d, %@.", (int)viewSize.width, (int)viewSize.height,(fullScreen ? @"fullscreen" : @"windowed"));
 	SDL_GL_SwapWindow(window);	// clear the buffer before resize
-	
-	SDL_SetWindowBordered(window, v_mode);
+
+	if (!fullScreen) {
+		SDL_SetWindowSize(window, viewSize.width, viewSize.height);
+		SDL_SetWindowBordered(window, v_mode);
+	}
 	SDL_SetWindowFullscreen(window, fullScreen);
-	SDL_SetWindowSize(window, viewSize.width, viewSize.height);
 	int w, h;
 	SDL_GetWindowSize(window, &w, &h);
 	bounds.size.width = w;

--- a/src/SDL/MyOpenGLView.m
+++ b/src/SDL/MyOpenGLView.m
@@ -1474,174 +1474,14 @@ finished:
 	OOLog(@"display.initGL", @"Requested a new surface of %d x %d, %@.", (int)viewSize.width, (int)viewSize.height,(fullScreen ? @"fullscreen" : @"windowed"));
 	SDL_GL_SwapWindow(window);	// clear the buffer before resize
 	
-#if OOLITE_WINDOWS
-	if (!updateContext) return;
-
-	DEVMODE settings;
-	settings.dmSize        = sizeof(DEVMODE);
-	settings.dmDriverExtra = 0;
-	EnumDisplaySettings(0, ENUM_CURRENT_SETTINGS, &settings);
-	
-	WINDOWPLACEMENT windowPlacement;
-	windowPlacement.length = sizeof(WINDOWPLACEMENT);
-	GetWindowPlacement(windowHandle, &windowPlacement);
-	
-	static BOOL lastWindowPlacementMaximized = NO;
-	if (fullScreen && (windowPlacement.showCmd == SW_SHOWMAXIMIZED))
-	{
-		if (!wasFullScreen)
-		{
-			lastWindowPlacementMaximized = YES;
-		}
-	}
-	
-	if (lastWindowPlacementMaximized)
-	{
-		windowPlacement.showCmd = SW_SHOWMAXIMIZED;
-	}
-	
-	// are we attempting to go to a different screen resolution? Note: this also takes care of secondary monitor situations because 
-	// by design the only resolution available for fullscreen on a secondary display device is its native one - Nikos 20150605
-	BOOL changingResolution = 	[self isRunningOnPrimaryDisplayDevice] &&
-								((fullScreen && (settings.dmPelsWidth != viewSize.width || settings.dmPelsHeight != viewSize.height)) ||
-								(wasFullScreen && (settings.dmPelsWidth != [[[screenSizes objectAtIndex:0] objectForKey: kOODisplayWidth] intValue]
-								|| settings.dmPelsHeight != [[[screenSizes objectAtIndex:0] objectForKey: kOODisplayHeight] intValue])));
-			
-	RECT wDC;
-
-	if (fullScreen)
-	{
-		/*NOTE: If we ever decide to change the default behaviour of launching
-		always on primary monitor to launching on the monitor the program was 
-		started on, all that needs to be done is comment out the line below, as
-		well as the identical one in the else branch further down.
-		Nikos 20141222
-	   */
-	   [self getCurrentMonitorInfo: &monitorInfo];
-		
-		settings.dmPelsWidth = viewSize.width;
-		settings.dmPelsHeight = viewSize.height;
-		settings.dmFields = DM_PELSWIDTH | DM_PELSHEIGHT;
-				
-		// just before going fullscreen, save the location of the current window. It
-		// may be needed in case of potential attempts to move our fullscreen window
-		// in a maximized state (yes, in Windows this is entirely possible).
-		if(lastWindowPlacementMaximized)
-		{
-			CopyRect(&lastGoodRect, &windowPlacement.rcNormalPosition);
-			// if maximized, switch to normal placement before going full screen
-			windowPlacement.showCmd = SW_SHOWNORMAL;
-			SetWindowPlacement(windowHandle, &windowPlacement);
-		}
-		else  GetWindowRect(windowHandle, &lastGoodRect);
-		
-		// ok, can go fullscreen now
-		SetForegroundWindow(windowHandle);
-		if (changingResolution)
-		{
-			if (ChangeDisplaySettingsEx(monitorInfo.szDevice, &settings, NULL, CDS_FULLSCREEN, NULL) != DISP_CHANGE_SUCCESSFUL)
-			{
-				m_glContextInitialized = YES;
-				OOLogERR(@"displayMode.change.error", @"Could not switch to requested display mode.");
-				return;
-			}
-			atDesktopResolution = settings.dmPelsWidth == [[[screenSizes objectAtIndex:0] objectForKey: kOODisplayWidth] intValue]
-								&& settings.dmPelsHeight == [[[screenSizes objectAtIndex:0] objectForKey: kOODisplayHeight] intValue];
-		}
-		
-		MoveWindow(windowHandle, monitorInfo.rcMonitor.left, monitorInfo.rcMonitor.top, (int)viewSize.width, (int)viewSize.height, TRUE);
-		if(!wasFullScreen)
-		{
-			[self setWindowBorderless:YES];
-		}
-	}
-	
-	else if ( wasFullScreen )
-	{
-		if (changingResolution)
-		{
-			// restore original desktop resolution
-			if (ChangeDisplaySettingsEx(NULL, NULL, NULL, 0, NULL) == DISP_CHANGE_SUCCESSFUL)
-			{
-				atDesktopResolution = YES;
-			}
-		}
-		
-		/*NOTE: If we ever decide to change the default behaviour of launching
-		always on primary monitor to launching on the monitor the program was 
-		started on, we need to comment out the line below.
-		For now, this line is needed for correct positioning of our window in case
-		we return from a non-native resolution fullscreen and has to come after the
-		display settings have been reverted.
-		Nikos 20141222
-		*/
-		[self getCurrentMonitorInfo: &monitorInfo];
-		
-		if (lastWindowPlacementMaximized)  CopyRect(&windowPlacement.rcNormalPosition, &lastGoodRect);
-		SetWindowPlacement(windowHandle, &windowPlacement);
-		if (!lastWindowPlacementMaximized)
-		{
-			MoveWindow(windowHandle,	(monitorInfo.rcMonitor.right - monitorInfo.rcMonitor.left - (int)viewSize.width)/2 +
-								monitorInfo.rcMonitor.left,
-								(monitorInfo.rcMonitor.bottom - monitorInfo.rcMonitor.top - (int)viewSize.height)/2 +
-								monitorInfo.rcMonitor.top,
-								(int)viewSize.width, (int)viewSize.height, TRUE);
-		}
-		
-		[self setWindowBorderless:NO];
-								
-		lastWindowPlacementMaximized = NO;
-		ShowWindow(windowHandle,SW_SHOW);
-	}
-	
-	// stop saveWindowSize from reacting to caption & frame if necessary
-	saveSize = !wasFullScreen;
-
-	GetClientRect(windowHandle, &wDC);
-
-	if (!fullScreen && (bounds.size.width != wDC.right - wDC.left
-					|| bounds.size.height != wDC.bottom - wDC.top))
-	{
-		// Resize the game window if needed. When we ask for a W x H
-		// window, we intend that the client area be W x H. The actual
-		// window itself must become big enough to accomodate an area
-		// of such size. 
-		if (wasFullScreen)	// this is true when switching from full screen or when starting in windowed mode
-							//after the splash screen has ended
-		{
-			RECT desiredClientRect;
-			GetWindowRect(windowHandle, &desiredClientRect);
-			AdjustWindowRect(&desiredClientRect, WS_CAPTION | WS_THICKFRAME, FALSE);
-			SetWindowPos(windowHandle, NULL,	desiredClientRect.left, desiredClientRect.top,
-											desiredClientRect.right - desiredClientRect.left,
-											desiredClientRect.bottom - desiredClientRect.top, 0);
-		}
-		GetClientRect(windowHandle, &wDC);
-		viewSize.width = wDC.right - wDC.left;
-		viewSize.height = wDC.bottom - wDC.top;
-	}
-
-	// Reset bounds and viewSize to current values
-	bounds.size.width = viewSize.width = wDC.right - wDC.left;
-	bounds.size.height = viewSize.height = wDC.bottom - wDC.top;
-	
-	if (fullScreen) // bounds on fullscreen coincide with client area, since we are borderless
-	{
-		bounds.origin.x = monitorInfo.rcMonitor.left;
-		bounds.origin.y = monitorInfo.rcMonitor.top;
-	}
-	wasFullScreen=fullScreen;
-
-#else //OOLITE_LINUX
-
 	SDL_SetWindowBordered(window, v_mode);
 	SDL_SetWindowFullscreen(window, fullScreen);
 	SDL_SetWindowSize(window, viewSize.width, viewSize.height);
-	SDL_Surface *surface = SDL_GetWindowSurface(window);
-	bounds.size.width = surface->w;
-	bounds.size.height = surface->h;
-
-#endif
+	int w, h;
+	SDL_GetWindowSize(window, &w, &h);
+	bounds.size.width = w;
+	bounds.size.height = h;
+	viewSize = bounds.size;
 	OOLog(@"display.initGL", @"Created a new surface of %d x %d, %@.", (int)viewSize.width, (int)viewSize.height,(fullScreen ? @"fullscreen" : @"windowed"));
 
 	if (viewSize.width/viewSize.height > 4.0/3.0) {
@@ -2082,7 +1922,6 @@ finished:
 	Uint16	 				key_id;
 	SDL_Scancode				scan_code;
 	float inDelta;
-    NSSize					newSize;
 	bool					resize_pending = false;
 
 	while (SDL_PollEvent(&event))
@@ -2473,7 +2312,6 @@ finished:
 
 			case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
 			{
-				newSize=NSMakeSize(event.window.data1, event.window.data2);
                 resize_pending = true;
 				break;
 			}
@@ -2514,30 +2352,30 @@ finished:
 	}
     if (resize_pending)
 	{
+		int pixelWidth, pixelHeight;  // Fetch actual pixel bounds back from SDL
+		SDL_GetWindowSizeInPixels(window, &pixelWidth, &pixelHeight);
+		bounds.size = NSMakeSize(pixelWidth, pixelHeight);
+		viewSize = bounds.size;
+
+		if (bounds.size.width / bounds.size.height > 4.0 / 3.0) {  // Recalculate aspect-ratio-dependent
+			display_z = 480.0 * bounds.size.width / bounds.size.height;  // projection offsets
+			x_offset = 240.0 * bounds.size.width / bounds.size.height;
+			y_offset = 240.0;
+		} else {
+			display_z = 640.0;
+			x_offset = 320.0;
+			y_offset = 320.0 * bounds.size.height / bounds.size.width;
+		}
+
+		float ratio = 0.5;  // Update OpenGL Viewport and Projection Matrix
+		float aspect = bounds.size.height / bounds.size.width;
+		OOGL(glViewport(0, 0, bounds.size.width, bounds.size.height));
+		OOGLResetProjection();
+		OOGLFrustum(-ratio, ratio, -aspect * ratio, aspect * ratio, 1.0, MAX_CLEAR_DEPTH);
+
 		if (!fullScreen)
 		{
-			int pixelWidth, pixelHeight;  // Fetch actual pixel bounds back from SDL
-			SDL_GetWindowSizeInPixels(window, &pixelWidth, &pixelHeight);
-			bounds.size = NSMakeSize(pixelWidth, pixelHeight);
-			viewSize = bounds.size;
-
-			if (bounds.size.width / bounds.size.height > 4.0 / 3.0) {  // Recalculate aspect-ratio-dependent
-				display_z = 480.0 * bounds.size.width / bounds.size.height;  // projection offsets
-				x_offset = 240.0 * bounds.size.width / bounds.size.height;
-				y_offset = 240.0;
-			} else {
-				display_z = 640.0;
-				x_offset = 320.0;
-				y_offset = 320.0 * bounds.size.height / bounds.size.width;
-			}
-
-			float ratio = 0.5;  // Update OpenGL Viewport and Projection Matrix
-			float aspect = bounds.size.height / bounds.size.width;
-			OOGL(glViewport(0, 0, bounds.size.width, bounds.size.height));
-			OOGLResetProjection();
-			OOGLFrustum(-ratio, ratio, -aspect * ratio, aspect * ratio, 1.0, MAX_CLEAR_DEPTH);
-
-			[self saveWindowSize: newSize];  // Save the updated window size
+			[self saveWindowSize: viewSize];  // Save the updated window size
 		}
 		resize_pending = false;
 	}

--- a/src/SDL/MyOpenGLView.m
+++ b/src/SDL/MyOpenGLView.m
@@ -1427,8 +1427,8 @@ finished:
 	else  // Hack for Windows SDL3 pause issue: https://github.com/libsdl-org/SDL/issues/12791
 	{     // Occurs on some systems eg. when going fullscreen -> window or vice versa
 		LONG currentWindowStyle = GetWindowLong(windowHandle, GWL_STYLE);
-    	currentWindowStyle &= ~WS_POPUP;
-    	SetWindowLong(windowHandle, GWL_STYLE, currentWindowStyle);
+		currentWindowStyle &= ~WS_POPUP;
+		SetWindowLong(windowHandle, GWL_STYLE, currentWindowStyle);
 	}
 #endif
 	int w, h;

--- a/src/SDL/MyOpenGLView.m
+++ b/src/SDL/MyOpenGLView.m
@@ -79,7 +79,6 @@ enum PreferredAppMode
 @interface MyOpenGLView (OOPrivate)
 
 - (void) resetSDLKeyModifiers;
-- (void) setWindowBorderless:(BOOL)borderless;
 - (void) handleStringInput: (SDL_KeyboardEvent *) kbd_event keyID:(Uint16)key_id; // DJS
 @end
 
@@ -725,11 +724,6 @@ enum PreferredAppMode
 		SDL_ShowWindow(window);
 #endif
 	}
-	// do screen resizing updates
-	if ([PlayerEntity sharedPlayer])
-	{
-		[[PlayerEntity sharedPlayer] doGuiScreenResizeUpdates];
-	}
 }
 
 
@@ -1086,28 +1080,6 @@ enum PreferredAppMode
 }
 
 
-- (void) setWindowBorderless:(BOOL)borderless
-{
-	LONG currentWindowStyle = GetWindowLong(windowHandle, GWL_STYLE);
-	
-	// window already has the desired style?
-	if ((!borderless && (currentWindowStyle & WS_CAPTION)) ||
-		(borderless && !(currentWindowStyle & WS_CAPTION)))  return;
-		
-	if (borderless)
-	{
-		SetWindowLong(windowHandle, GWL_STYLE, currentWindowStyle & ~WS_CAPTION & ~WS_THICKFRAME);
-	}
-	else
-	{
-		SetWindowLong(windowHandle, GWL_STYLE, currentWindowStyle |
-						WS_CAPTION | WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX );
-		[self refreshDarKOrLightMode];
-	}
-	SetWindowPos(windowHandle, NULL, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_FRAMECHANGED);
-}
-
-
 - (void) refreshDarKOrLightMode
 {
 	int shouldSetDarkMode = [self isDarkModeOn];
@@ -1401,12 +1373,6 @@ finished:
 }
 
 
-- (void) setWindowBorderless:(BOOL)borderless
-{
-	// do nothing on Linux
-}
-
-
 - (BOOL) hdrOutput
 {
 	return NO;
@@ -1451,11 +1417,20 @@ finished:
 	OOLog(@"display.initGL", @"Requested a new surface of %d x %d, %@.", (int)viewSize.width, (int)viewSize.height,(fullScreen ? @"fullscreen" : @"windowed"));
 	SDL_GL_SwapWindow(window);	// clear the buffer before resize
 
-	if (!fullScreen) {
+	SDL_SetWindowFullscreen(window, fullScreen);
+#if OOLITE_WINDOWS
+	if (fullScreen)  // Hack for Windows SDL3 pause issue: https://github.com/libsdl-org/SDL/issues/12791
+	{                // Occurs on some systems eg. when going fullscreen -> window or vice versa
+		LONG currentWindowStyle = GetWindowLong(windowHandle, GWL_STYLE);
+    	currentWindowStyle &= ~WS_POPUP;
+    	SetWindowLong(windowHandle, GWL_STYLE, currentWindowStyle);
+	}
+#endif
+	if (!fullScreen)
+	{
 		SDL_SetWindowSize(window, viewSize.width, viewSize.height);
 		SDL_SetWindowBordered(window, v_mode);
 	}
-	SDL_SetWindowFullscreen(window, fullScreen);
 	int w, h;
 	SDL_GetWindowSize(window, &w, &h);
 	bounds.size.width = w;

--- a/src/SDL/MyOpenGLView.m
+++ b/src/SDL/MyOpenGLView.m
@@ -1418,19 +1418,19 @@ finished:
 	SDL_GL_SwapWindow(window);	// clear the buffer before resize
 
 	SDL_SetWindowFullscreen(window, fullScreen);
-#if OOLITE_WINDOWS
-	if (fullScreen)  // Hack for Windows SDL3 pause issue: https://github.com/libsdl-org/SDL/issues/12791
-	{                // Occurs on some systems eg. when going fullscreen -> window or vice versa
-		LONG currentWindowStyle = GetWindowLong(windowHandle, GWL_STYLE);
-    	currentWindowStyle &= ~WS_POPUP;
-    	SetWindowLong(windowHandle, GWL_STYLE, currentWindowStyle);
-	}
-#endif
 	if (!fullScreen)
 	{
 		SDL_SetWindowSize(window, viewSize.width, viewSize.height);
 		SDL_SetWindowBordered(window, v_mode);
 	}
+#if OOLITE_WINDOWS
+	else  // Hack for Windows SDL3 pause issue: https://github.com/libsdl-org/SDL/issues/12791
+	{     // Occurs on some systems eg. when going fullscreen -> window or vice versa
+		LONG currentWindowStyle = GetWindowLong(windowHandle, GWL_STYLE);
+    	currentWindowStyle &= ~WS_POPUP;
+    	SetWindowLong(windowHandle, GWL_STYLE, currentWindowStyle);
+	}
+#endif
 	int w, h;
 	SDL_GetWindowSize(window, &w, &h);
 	bounds.size.width = w;


### PR DESCRIPTION
Remove Windows custom logic
Add one hack for Windows SDL3 pause issue: https://github.com/libsdl-org/SDL/issues/12791 that occurs on some systems eg. when going fullscreen -> window or vice versa
Remove dead code

@phkb Should be almost the same as what you tested but I had to change order of calls for Linux to work
```
	SDL_SetWindowFullscreen(window, fullScreen);
	if (!fullScreen)
	{
		SDL_SetWindowSize(window, viewSize.width, viewSize.height);
		SDL_SetWindowBordered(window, v_mode);
	}
#if OOLITE_WINDOWS
	else  // Hack for Windows SDL3 pause issue: https://github.com/libsdl-org/SDL/issues/12791
	{     // Occurs on some systems eg. when going fullscreen -> window or vice versa
		LONG currentWindowStyle = GetWindowLong(windowHandle, GWL_STYLE);
		currentWindowStyle &= ~WS_POPUP;
		SetWindowLong(windowHandle, GWL_STYLE, currentWindowStyle);
	}
#endif

```
