### PR TITLE
Override resourcePath instead of infoDictionary in NSBundle, MyOpenGLView code simplification

### DIFF
--- a/src/Core/GameController.m
+++ b/src/Core/GameController.m
@@ -404,7 +404,7 @@ static GameController *sSharedController = nil;
 	
 	@try
 	{
-		[gameView display];
+		[gameView updateScreen];
 	}
 	@catch (id exception) {}
 }

--- a/src/Core/NSBundle+Override.h
+++ b/src/Core/NSBundle+Override.h
@@ -1,11 +1,9 @@
 #import <Foundation/Foundation.h>
 
-@interface NSBundle (Override)
+@interface NSBundle (ResourceOverride)
 
-/**
- * Overrides the standard -infoDictionary method via a category name-clash.
- * Forces the bundle to manually load and return the contents of 'info-gnustep.plist'.
- */
-- (NSDictionary *)infoDictionary;
+// Declaring the swizzled method signature ensures clean compilation
+// if referenced internally and establishes the category interface.
+- (NSString *)oolite_resourcePath;
 
 @end

--- a/src/Core/NSBundle+Override.m
+++ b/src/Core/NSBundle+Override.m
@@ -1,51 +1,45 @@
-/*
- * NSBundle+Override.m
- *
- * Oolite Core Framework Override
- * Bypasses standard plist loading to manually locate and parse info-gnustep.plist
- * across Windows and Linux environments safely at boot.
- */
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
 
-#import "NSBundle+Override.h"
-#import <Foundation/NSFileManager.h>
-#import <Foundation/NSPathUtilities.h>
-#import <Foundation/NSDictionary.h>
+@implementation NSBundle (ResourceOverride)
 
-@implementation NSBundle (Override)
++ (void)load {
+  // Synchronously swizzle -resourcePath when the category is loaded into memory.
+  Class class = [self class];
+  SEL originalSelector = @selector(resourcePath);
+  SEL swizzledSelector = @selector(oolite_resourcePath);
 
-- (NSDictionary *)infoDictionary {
-	NSFileManager *fileManager = [NSFileManager defaultManager];
-	NSString *startingDir = [fileManager currentDirectoryPath];  // Start from cwd
+  Method originalMethod = class_getInstanceMethod(class, originalSelector);
+  Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
 
-	NSString *primaryResourcesPath = [startingDir stringByAppendingPathComponent:@"Resources"];
-	BOOL isDir = NO;
+  if (originalMethod && swizzledMethod) {
+    method_exchangeImplementations(originalMethod, swizzledMethod);
+  }
+}
 
-	NSString *resourcesFolder = nil;
-	if ([fileManager fileExistsAtPath:primaryResourcesPath isDirectory:&isDir] && isDir) {
-		resourcesFolder = primaryResourcesPath;
-	} else {
-		// Fallback: Look in startingDir / ../share/oolite/Resources (Standard Linux system layout)
-		NSString *fallbackPath = [[startingDir stringByDeletingLastPathComponent] stringByAppendingPathComponent:@"share/oolite/Resources"];
-		resourcesFolder = [fallbackPath stringByStandardizingPath];
-	}
+- (NSString *)oolite_resourcePath {
+  // Guard: Only apply custom path resolution to the main application bundle.
+  // GNUstep internal framework bundles will fall back to default behaviour.
+  if (self != [NSBundle mainBundle]) {
+    return [self oolite_resourcePath];
+  }
 
-	// Append the target file name to the resolved path root
-	NSString *plistPath = [resourcesFolder stringByAppendingPathComponent:@"Info-gnustep.plist"];
+  NSFileManager *fileManager = [NSFileManager defaultManager];
+  NSString *startingDir = [fileManager currentDirectoryPath];  // Start from cwd
 
-	// Load the target configuration file
-	NSDictionary *gnustepPlist = [NSDictionary dictionaryWithContentsOfFile:plistPath];
-	NSMutableDictionary *workingDict = nil;
+  NSString *primaryResourcesPath = [startingDir stringByAppendingPathComponent:@"Resources"];
+  BOOL isDir = NO;
 
-	if (gnustepPlist) {
-		workingDict = [gnustepPlist mutableCopy];
-	} else {
-		// Fallback block prevents runtime crashes if files are missing during dev/build refactors
-		workingDict = [[NSMutableDictionary alloc] init];
-		NSLog(@"[Oolite-Core] Warning: Failed to find info-gnustep.plist at calculated path: %@", plistPath);
-	}
+  NSString *resourcesFolder = nil;
+  if ([fileManager fileExistsAtPath:primaryResourcesPath isDirectory:&isDir] && isDir) {
+    resourcesFolder = primaryResourcesPath;
+  } else {
+    // Fallback: Look in startingDir / ../share/oolite/Resources (Standard Linux system layout)
+    NSString *fallbackPath = [[startingDir stringByDeletingLastPathComponent] stringByAppendingPathComponent:@"share/oolite/Resources"];
+    resourcesFolder = [fallbackPath stringByStandardizingPath];
+  }
 
-	// Return the dictionary cleanly managed for memory
-	return [workingDict autorelease];
+  return resourcesFolder;
 }
 
 @end

--- a/src/SDL/MyOpenGLView.h
+++ b/src/SDL/MyOpenGLView.h
@@ -289,7 +289,6 @@ extern int debug;
 - (void) noteMouseInteractionModeChangedFrom:(OOMouseInteractionMode)oldMode to:(OOMouseInteractionMode)newMode;
 
 - (void) initialiseGLWithSize:(NSSize) v_size;
-- (void) initialiseGLWithSize:(NSSize) v_size useVideoMode:(BOOL) v_mode;
 - (BOOL) isRunningOnPrimaryDisplayDevice;
 #if OOLITE_WINDOWS
 - (BOOL) getCurrentMonitorInfo:(MONITORINFOEX *)mInfo;
@@ -315,10 +314,7 @@ extern int debug;
 
 - (void) stringToClipboard:(NSString *)stringToCopy;
 
-- (void) drawRect:(NSRect)rect;
 - (void) updateScreen;
-- (void) updateScreenWithVideoMode:(BOOL) v_mode;
-- (void) display;
 
 - (BOOL) snapShot:(NSString *)filename;
 

--- a/src/SDL/MyOpenGLView.m
+++ b/src/SDL/MyOpenGLView.m
@@ -772,9 +772,6 @@ enum PreferredAppMode
 	SDL_GetWindowSize(window, &windowWidth, &windowHeight);
 	if ((viewSize.width != windowWidth)||(viewSize.height != windowHeight)) // resized
 	{
-#if OOLITE_LINUX
-		m_glContextInitialized = NO; //probably not needed
-#endif
 		viewSize.width = windowWidth;
 		viewSize.height = windowHeight;
 	}

--- a/src/SDL/MyOpenGLView.m
+++ b/src/SDL/MyOpenGLView.m
@@ -78,7 +78,6 @@ enum PreferredAppMode
 
 @interface MyOpenGLView (OOPrivate)
 
-- (void) resetSDLKeyModifiers;
 - (void) handleStringInput: (SDL_KeyboardEvent *) kbd_event keyID:(Uint16)key_id; // DJS
 @end
 
@@ -765,24 +764,9 @@ enum PreferredAppMode
 
 #endif
 
-- (void) display
-{
-	[self updateScreen];
-}
-
 - (void) updateScreen
 {
-	[self drawRect: NSMakeRect(0, 0, viewSize.width, viewSize.height)];
-}
-
-- (void) drawRect:(NSRect)rect
-{
-	SDL_SetWindowSize(window, (int)NSWidth(rect), (int)NSHeight(rect));
-	[self updateScreenWithVideoMode:YES];
-}
-
-- (void) updateScreenWithVideoMode:(BOOL) v_mode
-{
+	SDL_SetWindowSize(window, (int)viewSize.width, (int)viewSize.height);
 	SDL_Surface* surface = SDL_GetWindowSurface(window);
 	int windowWidth, windowHeight;
 	SDL_GetWindowSize(window, &windowWidth, &windowHeight);
@@ -797,7 +781,7 @@ enum PreferredAppMode
 
     if (m_glContextInitialized == NO)
 	{
-		[self initialiseGLWithSize:viewSize useVideoMode:v_mode];
+		[self initialiseGLWithSize:viewSize];
 	}
 
 	if (surface == 0)
@@ -1017,66 +1001,6 @@ enum PreferredAppMode
 			CloseClipboard();
 		}
 	}
-}
-
-
-- (void) resetSDLKeyModifiers
-{
-	/* kanthoney - looks like SDL3 won't allow us to change the keyboard state - try without to see if it's needed
-	// this is used when we regain focus to ensure that all
-	// modifier keys are reset to their correct status
-	SDL_Keymod modState = SDL_GetModState();
-	const BOOL *keyState = SDL_GetKeyboardState(NULL);
-	BYTE keyboardStatus[256];
-	#define OO_RESET_SDLKEY_MODIFIER(vkCode, kModCode, sdlkCode)	do {\
-	if (keyboardStatus[vkCode] & 0x0080) \
-	{ \
-		modState |= kModCode; \
-		keyState[sdlkCode] = SDL_PRESSED; \
-	} \
-	else \
-	{ \
-		modState &= ~kModCode; \
-		keyState[sdlkCode] = SDL_RELEASED; \
-	} \
-	} while(0)
-	if (GetKeyboardState(keyboardStatus))
-	{
-		// A bug noted here https://github.com/libsdl-org/SDL-1.2/issues/449
-		// was patched in SDL here https://github.com/libsdl-org/SDL-1.2/commit/09980c67290f11c3d088a6a039c550be83536c81
-		// This was replicated in our SDL binary (Windows-deps rev. 36fd5e6),
-		// so we no longer need to check the state of Alt when returning to the app.
-		// SDL change researched and implemented by Nikos 20220622.
-		// Alt key
-		//OO_RESET_SDLKEY_MODIFIER(VK_LMENU, KMOD_LALT, SDLK_LALT);
-		//OO_RESET_SDLKEY_MODIFIER(VK_RMENU, KMOD_RALT, SDLK_RALT);
-		//opt =  (modState & KMOD_LALT || modState & KMOD_RALT);
-		
-		//Ctrl key
-		OO_RESET_SDLKEY_MODIFIER(VK_LCONTROL, KMOD_LCTRL, SDLK_LCTRL);
-		OO_RESET_SDLKEY_MODIFIER(VK_RCONTROL, KMOD_RCTRL, SDLK_RCTRL);
-		ctrl =  (modState & KMOD_LCTRL || modState & KMOD_RCTRL);
-		
-		// Shift key
-		OO_RESET_SDLKEY_MODIFIER(VK_LSHIFT, KMOD_LSHIFT, SDLK_LSHIFT);
-		OO_RESET_SDLKEY_MODIFIER(VK_RSHIFT, KMOD_RSHIFT, SDLK_RSHIFT);
-		shift =  (modState & KMOD_LSHIFT || modState & KMOD_RSHIFT);
-		
-		// Caps Lock key state
-		if (GetKeyState(VK_CAPITAL) & 0x0001)
-		{
-			modState |= KMOD_CAPS;
-			keyState[SDLK_CAPSLOCK] = SDL_PRESSED;
-		}
-		else
-		{
-			modState &= ~KMOD_CAPS;
-			keyState[SDLK_CAPSLOCK] = SDL_RELEASED;
-		}
-	}
-	
-	SDL_SetModState(modState);
-	*/
 }
 
 
@@ -1367,12 +1291,6 @@ finished:
 }
 
 
-- (void) resetSDLKeyModifiers
-{
-	// probably not needed for Linux
-}
-
-
 - (BOOL) hdrOutput
 {
 	return NO;
@@ -1403,12 +1321,6 @@ finished:
 
 - (void) initialiseGLWithSize:(NSSize) v_size
 {
-	[self initialiseGLWithSize:v_size useVideoMode:YES];
-}
-
-
-- (void) initialiseGLWithSize:(NSSize) v_size useVideoMode:(BOOL) v_mode
-{
 	if (!window)
 	{
 		[self createWindowWithSize: v_size];
@@ -1421,7 +1333,7 @@ finished:
 	if (!fullScreen)
 	{
 		SDL_SetWindowSize(window, viewSize.width, viewSize.height);
-		SDL_SetWindowBordered(window, v_mode);
+		SDL_SetWindowBordered(window, YES);
 	}
 #if OOLITE_WINDOWS
 	else  // Hack for Windows SDL3 pause issue: https://github.com/libsdl-org/SDL/issues/12791


### PR DESCRIPTION
Fixes https://github.com/OoliteProject/oolite/issues/713
Further simple simplification
Removal of Linux hack that doesn't seem to be needed

Worked ok for me on Windows and Linux

@LW-archlinux, @phkb  please can you test

Also if this PR works for you, can you try this branch which builds on top of the changes in this PR (and makes some really nice simplifications): https://github.com/mcarans/oolite/tree/further_simplify ?