### PR TITLE
use arch rather than hardcode x86_64 in espeak-ng-data paths

### DIFF
--- a/ShellScripts/Linux/install_packages_root.sh
+++ b/ShellScripts/Linux/install_packages_root.sh
@@ -88,9 +88,9 @@ run_script() {
         fi
         install_gitversion "$outputdir"
         local espeak_folder="$(uname -m 2>/dev/null || echo x86_64)-linux-gnu"
-        if [[ ! -d /usr/share/espeak-ng-data &&
-              ! -d /usr/local/share/espeak-ng-data &&
-              ! -d /usr/lib/$espeak_folder/espeak-ng-data ]]; then
+        if [[ ! -d "/usr/share/espeak-ng-data" &&
+              ! -d "/usr/local/share/espeak-ng-data" &&
+              ! -d "/usr/lib/$espeak_folder/espeak-ng-data" ]]; then
             echo "❌ espeak-ng-data not in /usr/share, /usr/local/share or /usr/lib/$espeak_folder!"
             return 1
         fi

--- a/ShellScripts/Linux/install_packages_root.sh
+++ b/ShellScripts/Linux/install_packages_root.sh
@@ -87,13 +87,12 @@ run_script() {
             install_package python
         fi
         install_gitversion "$outputdir"
-        if [ ! -d /usr/share/espeak-ng-data ]; then
-            if [ ! -d /usr/local/share/espeak-ng-data ]; then
-                if [ ! -d /usr/lib/x86_64-linux-gnu/espeak-ng-data ]; then
-                    echo "❌ espeak-ng-data not in /usr/share, /usr/local/share or /usr/lib/x86_64-linux-gnu!"
-                    return 1
-                fi
-            fi
+        local espeak_folder="$(uname -m 2>/dev/null || echo x86_64)-linux-gnu"
+        if [[ ! -d /usr/share/espeak-ng-data &&
+              ! -d /usr/local/share/espeak-ng-data &&
+              ! -d /usr/lib/$espeak_folder/espeak-ng-data ]]; then
+            echo "❌ espeak-ng-data not in /usr/share, /usr/local/share or /usr/lib/$espeak_folder!"
+            return 1
         fi
     fi
 

--- a/ShellScripts/common/post_build.sh
+++ b/ShellScripts/common/post_build.sh
@@ -54,7 +54,7 @@ run_script() {
             # Linux search paths for espeak-ng-data
             local SEARCH_PATHS=(
                 "/usr/local/share/espeak-ng-data"
-                "/usr/lib/x86_64-linux-gnu/espeak-ng-data"
+                "/usr/lib/$(uname -m 2>/dev/null || echo x86_64)-linux-gnu/espeak-ng-data"
                 "/usr/share/espeak-ng-data"
                 "/app/share/espeak-ng-data"
             )


### PR DESCRIPTION
Basically does what's in this PR:
https://github.com/OoliteProject/oolite/pull/557